### PR TITLE
Add install script and project config support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,14 @@ jobs:
             capnp_ref: "v1.2.0"
             cxx_standard: "17"
             cxx_compiler: "c++"
+          - capnp_version: "1.3.0"
+            capnp_ref: "v1.3.0"
+            cxx_standard: "17"
+            cxx_compiler: "c++"
+          - capnp_version: "1.4.0"
+            capnp_ref: "v1.4.0"
+            cxx_standard: "17"
+            cxx_compiler: "c++"
           - capnp_version: "2.0-dev"
             capnp_ref: "v2"
             cxx_standard: "23"
@@ -61,22 +69,18 @@ jobs:
         run: ctest --test-dir build-${{ matrix.capnp_version }} --output-on-failure
 
   build_release:
-    name: Release Cap'n Proto ${{ matrix.capnp_version }}
+    name: Release Cap'n Proto ${{ matrix.capnp_channel }}
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         include:
-          - capnp_version: "1.1.0"
-            capnp_ref: "v1.1.0"
+          - capnp_channel: "v1"
+            capnp_ref: "v1.4.0"
             cxx_standard: "17"
             cxx_compiler: "c++"
-          - capnp_version: "1.2.0"
-            capnp_ref: "v1.2.0"
-            cxx_standard: "17"
-            cxx_compiler: "c++"
-          - capnp_version: "2.0-dev"
+          - capnp_channel: "v2"
             capnp_ref: "v2"
             cxx_standard: "23"
             cxx_compiler: "g++-14"
@@ -101,27 +105,35 @@ jobs:
         env:
           CXX: ${{ matrix.cxx_compiler }}
         run: |
-          cmake -B build-${{ matrix.capnp_version }} \
+          cmake -B build-${{ matrix.capnp_channel }} \
             -DCMAKE_CXX_STANDARD=${{ matrix.cxx_standard }} \
             -DCAPNP_SOURCE_DIR="${GITHUB_WORKSPACE}/capnproto/c++" .
 
       - name: Build
-        run: cmake --build build-${{ matrix.capnp_version }}
+        run: cmake --build build-${{ matrix.capnp_channel }}
 
       - name: Test
-        run: ctest --test-dir build-${{ matrix.capnp_version }} --output-on-failure
+        run: ctest --test-dir build-${{ matrix.capnp_channel }} --output-on-failure
 
       - name: Rename Binary
         run: |
           mv \
-            build-${{ matrix.capnp_version }}/capnp-ls \
-            build-${{ matrix.capnp_version }}/capnp-ls-linux-x86_64-capnp-${{ matrix.capnp_version }}
+            build-${{ matrix.capnp_channel }}/capnp-ls \
+            build-${{ matrix.capnp_channel }}/capnp-ls-linux-x86_64-capnp-${{ matrix.capnp_channel }}
+
+      - name: Generate Checksum
+        run: |
+          cd build-${{ matrix.capnp_channel }}
+          sha256sum capnp-ls-linux-x86_64-capnp-${{ matrix.capnp_channel }} \
+            > capnp-ls-linux-x86_64-capnp-${{ matrix.capnp_channel }}.sha256
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: capnp-ls-linux-x86_64-capnp-${{ matrix.capnp_version }}
-          path: build-${{ matrix.capnp_version }}/capnp-ls-linux-x86_64-capnp-${{ matrix.capnp_version }}
+          name: capnp-ls-linux-x86_64-capnp-${{ matrix.capnp_channel }}
+          path: |
+            build-${{ matrix.capnp_channel }}/capnp-ls-linux-x86_64-capnp-${{ matrix.capnp_channel }}
+            build-${{ matrix.capnp_channel }}/capnp-ls-linux-x86_64-capnp-${{ matrix.capnp_channel }}.sha256
 
   release:
     name: Create GitHub Release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,19 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - capnp_version: "1.1.0"
-            capnp_ref: "v1.1.0"
-            cxx_standard: "17"
-            cxx_compiler: "c++"
-          - capnp_version: "1.2.0"
-            capnp_ref: "v1.2.0"
-            cxx_standard: "17"
-            cxx_compiler: "c++"
-          - capnp_version: "1.3.0"
-            capnp_ref: "v1.3.0"
-            cxx_standard: "17"
-            cxx_compiler: "c++"
-          - capnp_version: "1.4.0"
+          - capnp_version: "v1"
             capnp_ref: "v1.4.0"
             cxx_standard: "17"
             cxx_compiler: "c++"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ add_executable(${exe_name}
     src/stdout_writer.cpp
     src/lsp_message_handler.cpp
     src/lsp_types.cpp
+    src/project_config.cpp
     src/utils.cpp
     src/linked_compiler.cpp
     src/compilation_manager.cpp
@@ -56,8 +57,41 @@ if(CAPNP_LS_BUILD_TESTS)
     enable_testing()
     add_executable(capnp-ls-linked-compiler-test
         tests/linked_compiler_test.cpp
+        src/project_config.cpp
         src/linked_compiler.cpp
         src/symbol_resolver.cpp
+    )
+    add_executable(capnp-ls-initialize-config-test
+        tests/initialize_config_test.cpp
+        src/stdout_writer.cpp
+        src/lsp_message_handler.cpp
+        src/lsp_types.cpp
+        src/project_config.cpp
+        src/utils.cpp
+        src/linked_compiler.cpp
+        src/compilation_manager.cpp
+        src/symbol_resolver.cpp
+    )
+    target_sources(capnp-ls-initialize-config-test PRIVATE
+        "${CAPNP_SOURCE_DIR}/src/capnp/compiler/module-loader.c++"
+    )
+    target_include_directories(capnp-ls-initialize-config-test BEFORE PRIVATE
+        ${CAPNP_SOURCE_DIR}/src
+    )
+    target_link_libraries(capnp-ls-initialize-config-test PRIVATE
+        capnp-json
+        capnpc
+        capnp
+        kj-async
+        kj
+    )
+    target_include_directories(capnp-ls-initialize-config-test PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src
+    )
+    target_compile_definitions(capnp-ls-initialize-config-test PRIVATE
+        CAPNP_LS_TESTING
+        CAPNP_LS_TEST_FIXTURE_DIR="${CMAKE_CURRENT_SOURCE_DIR}/samples/client/testFixture"
+        CAPNP_LS_CAPNP_SOURCE_DIR="${CAPNP_SOURCE_DIR}"
     )
     target_sources(capnp-ls-linked-compiler-test PRIVATE
         "${CAPNP_SOURCE_DIR}/src/capnp/compiler/module-loader.c++"
@@ -67,6 +101,7 @@ if(CAPNP_LS_BUILD_TESTS)
     )
     target_link_libraries(capnp-ls-linked-compiler-test PRIVATE
         capnpc
+        capnp-json
         capnp
         kj-async
         kj
@@ -79,4 +114,5 @@ if(CAPNP_LS_BUILD_TESTS)
         CAPNP_LS_CAPNP_SOURCE_DIR="${CAPNP_SOURCE_DIR}"
     )
     add_test(NAME linked-compiler COMMAND capnp-ls-linked-compiler-test)
+    add_test(NAME initialize-config COMMAND capnp-ls-initialize-config-test)
 endif()

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Cap'n Proto channel with environment variables:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/trickstar0301/capnp-ls/main/install.sh \
-  | CAPNP_LS_VERSION=v0.0.2 \
+  | CAPNP_LS_VERSION=v0.0.3 \
     CAPNP_LS_INSTALL_DIR="$HOME/.local/bin" \
     CAPNP_LS_CAPNP_VERSION=v2 \
     sh
@@ -106,7 +106,7 @@ To build a macOS arm64 release artifact locally:
 ```bash
 scripts/build-macos-arm64-release.sh v1 /path/to/capnproto-v1.4.0/c++
 gh release upload \
-  v0.0.2 \
+  v0.0.3 \
   dist/capnp-ls-macos-arm64-capnp-v1 \
   dist/capnp-ls-macos-arm64-capnp-v1.sha256 \
   --clobber

--- a/README.md
+++ b/README.md
@@ -2,6 +2,50 @@
 
 A language server that provides IDE features for Cap'n Proto schema files, including go-to-definition and automatic recompilation.
 
+## Installing
+
+Install the latest release binary:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/trickstar0301/capnp-ls/main/install.sh | sh
+```
+
+Or with `wget`:
+
+```bash
+wget -qO- https://raw.githubusercontent.com/trickstar0301/capnp-ls/main/install.sh | sh
+```
+
+By default, the installer downloads the `capnp-v1` binary into
+`$HOME/.local/bin`. Override the release version, install directory, or linked
+Cap'n Proto channel with environment variables:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/trickstar0301/capnp-ls/main/install.sh \
+  | CAPNP_LS_VERSION=v0.0.2 \
+    CAPNP_LS_INSTALL_DIR="$HOME/.local/bin" \
+    CAPNP_LS_CAPNP_VERSION=v2 \
+    sh
+```
+
+The installer verifies the release asset against its `.sha256` file before
+placing the executable on your `PATH`.
+
+## Claude Code and Copilot Plugins
+
+The Claude Code and Copilot plugins do not bundle the language server binary.
+Install `capnp-ls` first, then enable a plugin that starts:
+
+```json
+{
+  "command": "capnp-ls",
+  "args": ["--stdio"]
+}
+```
+
+Plugin marketplace definitions are maintained separately from this repository so
+one marketplace can host all `trickstar0301` plugins.
+
 ## Building from Source
 
 ### Prerequisites
@@ -9,8 +53,8 @@ A language server that provides IDE features for Cap'n Proto schema files, inclu
 - Supported OS: Linux, macOS arm64
 - CMake
 - Cap'n Proto C++ source tree
-- A C++17-capable compiler for Cap'n Proto `v1.1.0` and `v1.2.0`
-- A C++23-capable compiler and standard library for Cap'n Proto `v2` / `2.0-dev`
+- A C++17-capable compiler for Cap'n Proto `v1.1.0` through `v1.4.0`
+- A C++23-capable compiler and standard library for Cap'n Proto `v2`
 
 ### Build Instructions
 
@@ -21,7 +65,7 @@ cmake -B build -DCAPNP_SOURCE_DIR=/path/to/capnproto/c++ .
 cmake --build build
 ```
 
-When building against Cap'n Proto `v2` / `2.0-dev`, pass C++23 explicitly:
+When building against Cap'n Proto `v2`, pass C++23 explicitly:
 
 ```bash
 cmake -B build -DCMAKE_CXX_STANDARD=23 -DCAPNP_SOURCE_DIR=/path/to/capnproto/c++ .
@@ -36,40 +80,78 @@ Supported and tested Cap'n Proto source versions:
 
 - `v1.1.0`
 - `v1.2.0`
-- `v2` / `2.0-dev`
+- `v1.3.0`
+- `v1.4.0`
+- `v2`
 
 The executable for the language server is located at `build/capnp-ls`.
 
 ## Release Artifacts
 
-Release artifacts are versioned by the Cap'n Proto compiler source linked into
-the server binary.
+Release artifacts are versioned by the Cap'n Proto compatibility channel. Each
+artifact is published with a matching `.sha256` file. The `capnp-v1` artifacts
+are built against Cap'n Proto `v1.4.0` and tested with Cap'n Proto `v1.1.0`,
+`v1.2.0`, `v1.3.0`, and `v1.4.0`. The `capnp-v2` artifacts are built against
+the Cap'n Proto `v2` branch.
 
 Linux x86_64 artifacts are built by CI:
 
-- `capnp-ls-linux-x86_64-capnp-1.1.0`
-- `capnp-ls-linux-x86_64-capnp-1.2.0`
-- `capnp-ls-linux-x86_64-capnp-2.0-dev`
+- `capnp-ls-linux-x86_64-capnp-v1`
+- `capnp-ls-linux-x86_64-capnp-v2`
 
-macOS is supported for arm64 only. macOS arm64 artifacts are built locally by a
-maintainer and uploaded manually to the GitHub release:
+macOS arm64 artifacts are built locally by a maintainer and uploaded manually to
+the GitHub release:
 
-- `capnp-ls-macos-arm64-capnp-1.1.0`
-- `capnp-ls-macos-arm64-capnp-1.2.0`
-- `capnp-ls-macos-arm64-capnp-2.0-dev`
+- `capnp-ls-macos-arm64-capnp-v1`
+- `capnp-ls-macos-arm64-capnp-v2`
 
 To build a macOS arm64 release artifact locally:
 
 ```bash
-scripts/build-macos-arm64-release.sh 1.2.0 /path/to/capnproto/c++
-gh release upload v0.0.2 dist/capnp-ls-macos-arm64-capnp-1.2.0 --clobber
+scripts/build-macos-arm64-release.sh v1 /path/to/capnproto-v1.4.0/c++
+gh release upload \
+  v0.0.2 \
+  dist/capnp-ls-macos-arm64-capnp-v1 \
+  dist/capnp-ls-macos-arm64-capnp-v1.sha256 \
+  --clobber
 ```
+
+## Project Configuration
+
+Project-specific schema settings live in `.capnp-ls.json` at the workspace root.
+Commit this file with your schemas so every editor and agent uses the same
+Cap'n Proto import paths:
+
+```json
+{
+  "importPaths": [
+    "schemas/common",
+    "vendor/capnp"
+  ]
+}
+```
+
+Fields:
+
+- `importPaths`: An array of import paths for Cap'n Proto schemas.
+  - Relative paths are resolved from the workspace root.
+  - When multiple import paths are provided, they are searched in the specified order, similar to how the Cap'n Proto compiler operates.
+
+Clients should initialize the language server with either `workspaceFolders` or
+`rootUri` so `capnp-ls` can locate the workspace root. For Neovim and similar
+clients, use `.capnp-ls.json` or `.git` as the root marker.
+
+When the client sends watched-file notifications for `.capnp-ls.json`, the
+server reloads the config without a restart. Invalid JSON keeps the last valid
+configuration; deleting `.capnp-ls.json` clears project import paths.
 
 ## Language Server Protocol Support
 
 ### Initialization
 
-The language server requires the following initialization options:
+LSP clients may still pass initialization options explicitly. When
+`initializationOptions.capnp.importPaths` is present, it takes precedence over
+`.capnp-ls.json`:
 
 ```json
 {
@@ -82,9 +164,20 @@ The language server requires the following initialization options:
   }
 }
 ```
-Fields:
-- `importPaths`: An array of import paths for Cap'n Proto schemas.
-  - When multiple import paths are provided, they are searched in the specified order, similar to how the Cap'n Proto compiler operates.
+
+For clients that support project-level LSP configuration, the equivalent
+initialization options are:
+
+```json
+{
+  "capnp": {
+    "importPaths": [
+      "schemas/common",
+      "vendor/capnp"
+    ]
+  }
+}
+```
 
 ### Go to Definition
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ To build a macOS arm64 release artifact locally:
 
 ```bash
 scripts/build-macos-arm64-release.sh 1.2.0 /path/to/capnproto/c++
-gh release upload v0.0.1 dist/capnp-ls-macos-arm64-capnp-1.2.0 --clobber
+gh release upload v0.0.2 dist/capnp-ls-macos-arm64-capnp-1.2.0 --clobber
 ```
 
 ## Language Server Protocol Support

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ one marketplace can host all `trickstar0301` plugins.
 - Supported OS: Linux, macOS arm64
 - CMake
 - Cap'n Proto C++ source tree
-- A C++17-capable compiler for Cap'n Proto `v1.1.0` through `v1.4.0`
+- A C++17-capable compiler for Cap'n Proto `v1`
 - A C++23-capable compiler and standard library for Cap'n Proto `v2`
 
 ### Build Instructions
@@ -76,12 +76,9 @@ The linked compiler backend builds and links Cap'n Proto from the selected sourc
 tree. To support another Cap'n Proto version, build the same `capnp-ls` source
 with `CAPNP_SOURCE_DIR` pointing at that version's C++ source tree.
 
-Supported and tested Cap'n Proto source versions:
+Supported Cap'n Proto source channels:
 
-- `v1.1.0`
-- `v1.2.0`
-- `v1.3.0`
-- `v1.4.0`
+- `v1` (built and tested against `v1.4.0`)
 - `v2`
 
 The executable for the language server is located at `build/capnp-ls`.
@@ -90,9 +87,8 @@ The executable for the language server is located at `build/capnp-ls`.
 
 Release artifacts are versioned by the Cap'n Proto compatibility channel. Each
 artifact is published with a matching `.sha256` file. The `capnp-v1` artifacts
-are built against Cap'n Proto `v1.4.0` and tested with Cap'n Proto `v1.1.0`,
-`v1.2.0`, `v1.3.0`, and `v1.4.0`. The `capnp-v2` artifacts are built against
-the Cap'n Proto `v2` branch.
+are built and tested against Cap'n Proto `v1.4.0`. The `capnp-v2` artifacts are
+built and tested against the Cap'n Proto `v2` branch.
 
 Linux x86_64 artifacts are built by CI:
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env sh
+set -eu
+
+REPO="${CAPNP_LS_REPO:-trickstar0301/capnp-ls}"
+VERSION="${CAPNP_LS_VERSION:-latest}"
+INSTALL_DIR="${CAPNP_LS_INSTALL_DIR:-$HOME/.local/bin}"
+CAPNP_VERSION="${CAPNP_LS_CAPNP_VERSION:-v1}"
+DOWNLOAD_BASE_URL="${CAPNP_LS_DOWNLOAD_BASE_URL:-https://github.com/$REPO/releases/download}"
+GITHUB_API_URL="${CAPNP_LS_GITHUB_API_URL:-https://api.github.com/repos/$REPO/releases/latest}"
+
+need_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+download() {
+  url="$1"
+  output="$2"
+
+  if command -v curl >/dev/null 2>&1; then
+    curl -fsSL "$url" -o "$output"
+  elif command -v wget >/dev/null 2>&1; then
+    wget -qO "$output" "$url"
+  else
+    echo "Missing required command: curl or wget" >&2
+    exit 1
+  fi
+}
+
+detect_os() {
+  case "${CAPNP_LS_OS:-$(uname -s)}" in
+    Darwin|darwin|macOS|macos) echo "macos" ;;
+    Linux|linux) echo "linux" ;;
+    *) echo "Unsupported OS: ${CAPNP_LS_OS:-$(uname -s)}" >&2; exit 1 ;;
+  esac
+}
+
+detect_arch() {
+  case "${CAPNP_LS_ARCH:-$(uname -m)}" in
+    x86_64|amd64) echo "x86_64" ;;
+    arm64|aarch64) echo "arm64" ;;
+    *) echo "Unsupported architecture: ${CAPNP_LS_ARCH:-$(uname -m)}" >&2; exit 1 ;;
+  esac
+}
+
+normalize_capnp_version() {
+  case "$1" in
+    v1|1|1.x|1.1.0|1.2.0|1.3.0|1.4.0) echo "v1" ;;
+    v2|2|2.x|2.0-dev) echo "v2" ;;
+    *) echo "Unsupported Cap'n Proto version channel: $1" >&2; exit 1 ;;
+  esac
+}
+
+verify_checksum() {
+  file="$1"
+  checksum_file="$2"
+
+  if command -v sha256sum >/dev/null 2>&1; then
+    (cd "$(dirname "$file")" && sha256sum -c "$(basename "$checksum_file")")
+    return
+  fi
+
+  need_command shasum
+  expected="$(awk '{print $1}' "$checksum_file")"
+  actual="$(shasum -a 256 "$file" | awk '{print $1}')"
+  if [ "$expected" != "$actual" ]; then
+    echo "Checksum mismatch" >&2
+    echo "Expected: $expected" >&2
+    echo "Actual:   $actual" >&2
+    exit 1
+  fi
+}
+
+validate_platform() {
+  os_name="$1"
+  arch_name="$2"
+
+  case "${os_name}-${arch_name}" in
+    linux-x86_64|macos-arm64) ;;
+    *)
+      echo "Unsupported release platform: ${os_name}-${arch_name}" >&2
+      echo "Published binaries are currently available for linux-x86_64 and macos-arm64." >&2
+      exit 1
+      ;;
+  esac
+}
+
+if [ "$VERSION" = "latest" ]; then
+  tmp_latest="$(mktemp)"
+  download "$GITHUB_API_URL" "$tmp_latest"
+  VERSION="$(sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p' "$tmp_latest" | head -n 1)"
+  rm -f "$tmp_latest"
+  if [ -z "$VERSION" ]; then
+    echo "Could not resolve latest release version." >&2
+    exit 1
+  fi
+fi
+
+OS_NAME="$(detect_os)"
+ARCH_NAME="$(detect_arch)"
+validate_platform "$OS_NAME" "$ARCH_NAME"
+CAPNP_CHANNEL="$(normalize_capnp_version "$CAPNP_VERSION")"
+ASSET="capnp-ls-${OS_NAME}-${ARCH_NAME}-capnp-${CAPNP_CHANNEL}"
+URL="${DOWNLOAD_BASE_URL}/${VERSION}/${ASSET}"
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+echo "Downloading ${ASSET} from ${VERSION}..."
+download "$URL" "$TMP_DIR/$ASSET"
+download "$URL.sha256" "$TMP_DIR/$ASSET.sha256"
+verify_checksum "$TMP_DIR/$ASSET" "$TMP_DIR/$ASSET.sha256"
+
+chmod +x "$TMP_DIR/$ASSET"
+mkdir -p "$INSTALL_DIR"
+mv "$TMP_DIR/$ASSET" "$INSTALL_DIR/capnp-ls"
+
+echo "Installed capnp-ls to $INSTALL_DIR/capnp-ls"
+
+case ":$PATH:" in
+  *":$INSTALL_DIR:"*) ;;
+  *)
+    echo ""
+    echo "Warning: $INSTALL_DIR is not in your PATH."
+    echo "Add this to your shell profile:"
+    echo "  export PATH=\"$INSTALL_DIR:\$PATH\""
+    ;;
+esac
+
+"$INSTALL_DIR/capnp-ls" --version || true

--- a/justfile
+++ b/justfile
@@ -1,0 +1,19 @@
+build_dir := env_var_or_default("CAPNP_LS_BUILD_DIR", "build")
+capnp_source_dir := env_var_or_default("CAPNP_SOURCE_DIR", "")
+
+test:
+    if [ ! -f "{{build_dir}}/CMakeCache.txt" ]; then \
+      if [ -z "{{capnp_source_dir}}" ]; then \
+        echo "Set CAPNP_SOURCE_DIR to configure {{build_dir}}."; \
+        exit 2; \
+      fi; \
+      cmake -B "{{build_dir}}" -DCAPNP_SOURCE_DIR="{{capnp_source_dir}}" .; \
+    fi
+    cmake --build "{{build_dir}}"
+    ctest --test-dir "{{build_dir}}" --output-on-failure
+    sh -n install.sh
+    sh tests/install_sh_test.sh
+
+test-install:
+    sh -n install.sh
+    sh tests/install_sh_test.sh

--- a/samples/.vscodeignore
+++ b/samples/.vscodeignore
@@ -3,17 +3,22 @@ client/src/**
 client/testFixture/**
 
 # Build and configuration files
+.vscode/**
 client/tsconfig.json
 client/tsconfig.tsbuildinfo
+client/package.json
+client/pnpm-lock.yaml
 tsconfig.json
+eslint.config.js
 
 # Test files
 client/out/test/**
 scripts/**
 
 # Node.js files
-node_modules/**
+client/node_modules/**
 package-lock.json
+pnpm-lock.yaml
 
 # Documentation
 README.md

--- a/samples/README.md
+++ b/samples/README.md
@@ -38,7 +38,7 @@ Project-specific import paths are read by the language server from
 }
 ```
 
-To customize client settings, edit the `.vscode/settings.json` file in your workspace as follows:
+To customize client settings, configure them in VS Code User Settings:
 
 ```json
 {
@@ -49,8 +49,6 @@ To customize client settings, edit the `.vscode/settings.json` file in your work
     }
 }
 ```
-See [example configuration](https://github.com/trickstar0301/capnp-ls/blob/main/samples/client/testFixture/.vscode/settings.json) for more details.
-
 ## Release Artifact Availability
 
 Linux x86_64 release artifacts are built by CI. macOS arm64 release artifacts

--- a/samples/README.md
+++ b/samples/README.md
@@ -16,11 +16,10 @@ A VS Code extension that provides language support for Cap'n Proto schema files.
 
 This extension contributes the following settings:
 
-* `capnp-ls-client.languageServer.path`: Path to the Cap'n Proto language server executable. If not specified, the extension uses the versioned binary for `capnp-ls-client.languageServer.capnpVersion` from the extension directory. For Linux x86_64 and macOS arm64 systems, that binary will be automatically downloaded if it is available in the configured GitHub release.
+* `capnp-ls-client.languageServer.path`: Path to the Cap'n Proto language server executable. If not specified, the extension uses the versioned binary for `capnp-ls-client.languageServer.capnpChannel` from the extension directory. For Linux x86_64 and macOS arm64 systems, that binary will be automatically downloaded if it is available in the configured GitHub release.
 * `capnp-ls-client.languageServer.version`: capnp-ls release tag used for automatic Linux x86_64 and macOS arm64 downloads.
-* `capnp-ls-client.languageServer.capnpVersion`: Cap'n Proto compiler version linked into the automatically downloaded language server binary. Supported values are `1.1.0`, `1.2.0`, and `2.0-dev`.
-  * Changing the server path, release version, or linked Cap'n Proto version prompts you to reload VS Code so the new server binary is used.
-* `capnp-ls-client.compiler.importPaths`: Additional import paths for Cap'n Proto schemas.
+* `capnp-ls-client.languageServer.capnpChannel`: Cap'n Proto compatibility channel for the automatically downloaded language server binary. Supported values are `v1` and `v2`.
+  * Changing the server path, release version, or Cap'n Proto channel prompts you to reload VS Code so the new server binary is used.
 * `capnp-ls-client.server.extraEnv`: Extra environment variables that will be passed to the capnp-ls executable.
   * `CPP_LOG`: Log level for the Cap'n Proto language server.
     * Example: `CPP_LOG=lsp_server=info`: Set log level to info.
@@ -28,15 +27,23 @@ This extension contributes the following settings:
 
 #### Example configuration:
 
-To customize the client settings, edit the `.vscode/settings.json` file in your workspace as follows:
+Project-specific import paths are read by the language server from
+`.capnp-ls.json` in your workspace root:
+
+```json
+{
+    "importPaths": [
+        "path/to/schema/imports"
+    ]
+}
+```
+
+To customize client settings, edit the `.vscode/settings.json` file in your workspace as follows:
 
 ```json
 {
     "capnp-ls-client.languageServer.path": "/absolute/path/to/capnp-ls",
-    "capnp-ls-client.languageServer.capnpVersion": "1.2.0",
-    "capnp-ls-client.compiler.importPaths": [
-        "path/to/schema/imports"
-    ],
+    "capnp-ls-client.languageServer.capnpChannel": "v1",
     "capnp-ls-client.server.extraEnv": {
         "CPP_LOG": "lsp_server=warning"
     }
@@ -51,8 +58,10 @@ are built locally by a maintainer and uploaded manually. The VS Code extension
 uses the following asset names:
 
 ```text
-capnp-ls-linux-x86_64-capnp-1.2.0
-capnp-ls-macos-arm64-capnp-1.2.0
+capnp-ls-linux-x86_64-capnp-v1
+capnp-ls-linux-x86_64-capnp-v2
+capnp-ls-macos-arm64-capnp-v1
+capnp-ls-macos-arm64-capnp-v2
 ```
 
 Windows and macOS x86_64 are not supported.

--- a/samples/client/src/extension.ts
+++ b/samples/client/src/extension.ts
@@ -5,6 +5,7 @@
 
 import * as path from 'path';
 import * as fs from 'fs';
+import * as crypto from 'crypto';
 import { workspace, ExtensionContext, window, commands } from 'vscode';
 import * as https from 'https';
 
@@ -20,7 +21,7 @@ type ReleasePlatform = 'linux-x86_64' | 'macos-arm64';
 
 // Default language server version for downloadable release binaries.
 const DEFAULT_SERVER_VERSION = 'v0.0.2';
-const DEFAULT_CAPNP_VERSION = '1.2.0';
+const DEFAULT_CAPNP_CHANNEL = 'v1';
 
 export async function activate(context: ExtensionContext) {
 	if (process.platform === 'win32') {
@@ -35,7 +36,7 @@ export async function activate(context: ExtensionContext) {
 	context.subscriptions.push(
 		workspace.onDidChangeConfiguration(async event => {
 			if (
-				event.affectsConfiguration('capnp-ls-client.languageServer.capnpVersion') ||
+				event.affectsConfiguration('capnp-ls-client.languageServer.capnpChannel') ||
 				event.affectsConfiguration('capnp-ls-client.languageServer.version') ||
 				event.affectsConfiguration('capnp-ls-client.languageServer.path')
 			) {
@@ -61,14 +62,10 @@ export async function activate(context: ExtensionContext) {
 	// Get configuration
 	const config = workspace.getConfiguration('capnp-ls-client');
 	const serverPathRaw = config.get<string>('languageServer.path');
-	const importPathsRaw = config.get<string[]>('compiler.importPaths') || [];
 	const extraEnv = config.get<Record<string, string | number>>('server.extraEnv') || {};
 	// Get server version from configuration or use default
 	const serverVersion = config.get<string>('languageServer.version') || DEFAULT_SERVER_VERSION;
-	const capnpVersion = config.get<string>('languageServer.capnpVersion') || DEFAULT_CAPNP_VERSION;
-
-	// Resolve environment variables in paths
-	const resolvedImportPaths = importPathsRaw.map(p => resolveEnvVars(p));
+	const capnpChannel = config.get<string>('languageServer.capnpChannel') || DEFAULT_CAPNP_CHANNEL;
 
 	// Helper function to resolve environment variables in paths
 	function resolveEnvVars(pathStr: string): string {
@@ -112,7 +109,7 @@ export async function activate(context: ExtensionContext) {
 			: context.asAbsolutePath(serverPath);
 	} else {
 		try {
-			resolvedServerPath = await findLanguageServer(context, serverVersion, capnpVersion);
+			resolvedServerPath = await findLanguageServer(context, serverVersion, capnpChannel);
 		} catch (err) {
 			const message = errorMessage(err);
 			log(message);
@@ -121,9 +118,21 @@ export async function activate(context: ExtensionContext) {
 		}
 	}
 
-	async function findLanguageServer(context: ExtensionContext, version: string, capnpVersion: string): Promise<string> {
+	function normalizeCapnpChannel(capnpChannel: string): string {
+		switch (capnpChannel) {
+			case 'v1':
+				return 'v1';
+			case 'v2':
+				return 'v2';
+			default:
+				return capnpChannel;
+		}
+	}
+
+	async function findLanguageServer(context: ExtensionContext, version: string, capnpChannel: string): Promise<string> {
 		const extensionPath = context.extensionPath;
-		const versionedBinaryName = `capnp-ls-capnp-${capnpVersion}`;
+		const normalizedCapnpChannel = normalizeCapnpChannel(capnpChannel);
+		const versionedBinaryName = `capnp-ls-capnp-${normalizedCapnpChannel}`;
 		const extensionVersionedBinaryPath = path.join(extensionPath, versionedBinaryName);
 
 		if (fs.existsSync(extensionVersionedBinaryPath)) {
@@ -140,8 +149,8 @@ export async function activate(context: ExtensionContext) {
 		if (releasePlatform && !fs.existsSync(extensionVersionedBinaryPath)) {
 			log(`Binary not found at ${extensionVersionedBinaryPath} and we're on ${releasePlatform}, attempting to download...`);
 			try {
-				await downloadCapnpLs(extensionVersionedBinaryPath, version, capnpVersion, releasePlatform);
-				log(`Successfully downloaded capnp-ls version ${version} for Cap'n Proto ${capnpVersion} to ${extensionVersionedBinaryPath}`);
+				await downloadCapnpLs(extensionVersionedBinaryPath, version, normalizedCapnpChannel, releasePlatform);
+				log(`Successfully downloaded capnp-ls version ${version} for Cap'n Proto ${normalizedCapnpChannel} to ${extensionVersionedBinaryPath}`);
 				return extensionVersionedBinaryPath;
 			} catch (err) {
 				log(`Failed to download capnp-ls: ${errorMessage(err)}`);
@@ -149,200 +158,89 @@ export async function activate(context: ExtensionContext) {
 		}
 
 		throw new Error(
-			`Could not find capnp-ls linked with Cap'n Proto ${capnpVersion}. ` +
+			`Could not find capnp-ls for Cap'n Proto ${normalizedCapnpChannel}. ` +
 			`Set capnp-ls-client.languageServer.path explicitly or install ${versionedBinaryName} in the extension directory.`
 		);
 	}
 
-	function downloadCapnpLs(targetPath: string, version: string, capnpVersion: string, platform: ReleasePlatform): Promise<void> {
-		const assetName = `capnp-ls-${platform}-capnp-${capnpVersion}`;
+	function downloadCapnpLs(targetPath: string, version: string, capnpChannel: string, platform: ReleasePlatform): Promise<void> {
+		const assetName = `capnp-ls-${platform}-capnp-${capnpChannel}`;
 		const url = `https://github.com/trickstar0301/capnp-ls/releases/download/${version}/${assetName}`;
-		log(`Downloading capnp-ls version ${version} for Cap'n Proto ${capnpVersion} from ${url} to ${targetPath}`);
+		log(`Downloading capnp-ls version ${version} for Cap'n Proto ${capnpChannel} from ${url} to ${targetPath}`);
+		return downloadFile(url, targetPath)
+			.then(() => verifyDownloadedChecksum(targetPath, `${url}.sha256`))
+			.then(() => fs.promises.chmod(targetPath, 0o755))
+			.then(() => {
+				log('Download completed, checksum verified, and file made executable');
+			})
+			.catch(err => {
+				fs.unlink(targetPath, () => {});
+				throw err;
+			});
+	}
 
+	function requestUrl(url: string): Promise<Buffer> {
 		return new Promise((resolve, reject) => {
-			// Open the file only after the download response is accepted.
-			let file: fs.WriteStream | null = null;
-			
-			// GitHub may require a User-Agent header.
-			const options = {
+			const request = https.get(url, {
 				headers: {
 					'User-Agent': 'VSCode-CapnProto-Extension',
 					'Accept': 'application/octet-stream'
-				},
-				followRedirects: true
-			};
-
-			log(`Sending request with options: ${JSON.stringify(options)}`);
-
-			const request = https.get(url, options, (response) => {
-				log(`Received response with status code: ${response.statusCode}`);
-				log(`Response headers: ${JSON.stringify(response.headers)}`);
-
-				if (response.statusCode === 302 || response.statusCode === 301) {
+				}
+			}, response => {
+				if (response.statusCode === 301 || response.statusCode === 302) {
 					const redirectUrl = response.headers.location;
+					response.resume();
 					if (!redirectUrl) {
 						reject(new Error(`Redirect location not found: ${response.statusCode} ${response.statusMessage}`));
 						return;
 					}
-
-					log(`Following redirect to: ${redirectUrl}`);
-
-					request.destroy();
-
-					const redirectUrlObj = new URL(redirectUrl);
-					const redirectOptions = {
-						host: redirectUrlObj.hostname,
-						path: redirectUrlObj.pathname + redirectUrlObj.search,
-						headers: {
-							'User-Agent': 'VSCode-CapnProto-Extension',
-							'Accept': 'application/octet-stream'
-						}
-					};
-
-					log(`Sending redirect request with options: ${JSON.stringify(redirectOptions)}`);
-
-					https.get(redirectOptions, (redirectResponse) => {
-						log(`Redirect response status: ${redirectResponse.statusCode}`);
-						log(`Redirect response headers: ${JSON.stringify(redirectResponse.headers)}`);
-
-						if (redirectResponse.statusCode !== 200) {
-							reject(new Error(`Failed to download from redirect: ${redirectResponse.statusCode} ${redirectResponse.statusMessage}`));
-							return;
-						}
-
-						file = fs.createWriteStream(targetPath);
-						let downloadedBytes = 0;
-
-						redirectResponse.on('data', (chunk) => {
-							downloadedBytes += chunk.length;
-							if (downloadedBytes % (1024 * 1024) === 0) {
-								log(`Downloaded ${downloadedBytes / 1024 / 1024} MB...`);
-							}
-						});
-
-						redirectResponse.pipe(file);
-
-						file.on('finish', () => {
-							if (file) file.close();
-
-							fs.stat(targetPath, (err, stats) => {
-								if (err) {
-									log(`Error checking file size: ${err.message}`);
-									reject(err);
-									return;
-								}
-
-								if (stats.size === 0) {
-									log('Error: Downloaded file is empty (0 bytes)');
-									fs.unlink(targetPath, () => {});
-									reject(new Error('Downloaded file is empty'));
-									return;
-								}
-
-								log(`Downloaded file size: ${stats.size} bytes`);
-
-								fs.chmod(targetPath, 0o755, (err) => {
-									if (err) {
-										log(`Error making file executable: ${err.message}`);
-										reject(err);
-										return;
-									}
-									log('Download completed and file made executable');
-									resolve();
-								});
-							});
-						});
-
-						file.on('error', (err) => {
-							if (file) file.close();
-							fs.unlink(targetPath, () => {}); // Delete the file on error
-							log(`Error downloading file from redirect: ${err.message}`);
-							reject(err);
-						});
-					}).on('error', (err) => {
-						fs.unlink(targetPath, () => {}); // Delete the file on error
-						log(`Error following redirect: ${err.message}`);
-						reject(err);
-					});
-
+					resolve(requestUrl(redirectUrl));
 					return;
 				}
 
 				if (response.statusCode !== 200) {
+					response.resume();
 					reject(new Error(`Failed to download: ${response.statusCode} ${response.statusMessage}`));
 					return;
 				}
 
-				file = fs.createWriteStream(targetPath);
-				let downloadedBytes = 0;
-
-				response.on('data', (chunk) => {
-					downloadedBytes += chunk.length;
-					if (downloadedBytes % (1024 * 1024) === 0) {
-						log(`Downloaded ${downloadedBytes / 1024 / 1024} MB...`);
-					}
-				});
-
-				response.pipe(file);
-
-				file.on('finish', () => {
-					if (file) file.close();
-
-					fs.stat(targetPath, (err, stats) => {
-						if (err) {
-							log(`Error checking file size: ${err.message}`);
-							reject(err);
-							return;
-						}
-
-						if (stats.size === 0) {
-							log('Error: Downloaded file is empty (0 bytes)');
-							fs.unlink(targetPath, () => {});
-							reject(new Error('Downloaded file is empty'));
-							return;
-						}
-
-						log(`Downloaded file size: ${stats.size} bytes`);
-
-						fs.chmod(targetPath, 0o755, (err) => {
-							if (err) {
-								log(`Error making file executable: ${err.message}`);
-								reject(err);
-								return;
-							}
-							log('Download completed and file made executable');
-							resolve();
-						});
-					});
-				});
-
-				file.on('error', (err) => {
-					if (file) file.close();
-					fs.unlink(targetPath, () => {}); // Delete the file on error
-					log(`Error downloading file: ${err.message}`);
-					reject(err);
-				});
-			}).on('error', (err) => {
-				if (file) file.close();
-				fs.unlink(targetPath, () => {}); // Delete the file on error
-				log(`Error downloading file: ${err.message}`);
-				reject(err);
-			});
+				const chunks: Buffer[] = [];
+				response.on('data', chunk => chunks.push(Buffer.from(chunk)));
+				response.on('end', () => resolve(Buffer.concat(chunks)));
+				response.on('error', reject);
+			}).on('error', reject);
 
 			request.setTimeout(30000, () => {
 				request.destroy();
-				if (file) file.close();
-				fs.unlink(targetPath, () => {});
 				reject(new Error('Download timed out after 30 seconds'));
 			});
 		});
 	}
 
-	log(`Server path: ${resolvedServerPath}`);
-	log(`Cap'n Proto linked version: ${capnpVersion}`);
-	log(`Import paths: ${resolvedImportPaths.join(', ')}`);
+	async function downloadFile(url: string, targetPath: string): Promise<void> {
+		const data = await requestUrl(url);
+		if (data.length === 0) {
+			throw new Error('Downloaded file is empty');
+		}
+		await fs.promises.writeFile(targetPath, data, { mode: 0o644 });
+		log(`Downloaded file size: ${data.length} bytes`);
+	}
 
-	// Server options
+	async function verifyDownloadedChecksum(targetPath: string, checksumUrl: string): Promise<void> {
+		const checksumText = (await requestUrl(checksumUrl)).toString('utf8');
+		const expected = checksumText.trim().split(/\s+/)[0];
+		const file = await fs.promises.readFile(targetPath);
+		const actual = crypto.createHash('sha256').update(file).digest('hex');
+		if (expected !== actual) {
+			throw new Error(`Checksum mismatch for ${targetPath}: expected ${expected}, got ${actual}`);
+		}
+		log('Checksum verified');
+	}
+
+	log(`Server path: ${resolvedServerPath}`);
+	log(`Cap'n Proto channel: ${normalizeCapnpChannel(capnpChannel)}`);
+
+		// Server options
 	const serverOptions: ServerOptions = {
 		command: resolvedServerPath,
 		args: [],
@@ -358,15 +256,13 @@ export async function activate(context: ExtensionContext) {
 	const clientOptions: LanguageClientOptions = {
 		documentSelector: [{ scheme: 'file', language: 'capnp' }],
 		synchronize: {
-			fileEvents: workspace.createFileSystemWatcher('**/*.capnp')
+			fileEvents: [
+				workspace.createFileSystemWatcher('**/*.capnp'),
+				workspace.createFileSystemWatcher('**/.capnp-ls.json')
+			]
 		},
 		outputChannel: outputChannel,
 		workspaceFolder: workspaceFolder,
-		initializationOptions: {
-			capnp: {
-				importPaths: resolvedImportPaths
-			}
-		},
 		middleware: {
 			provideDefinition: (document, position, token, next) => {
 				log(`Definition requested at position: ${position.line}:${position.character}`);

--- a/samples/client/src/extension.ts
+++ b/samples/client/src/extension.ts
@@ -19,10 +19,6 @@ let client: LanguageClient;
 
 type ReleasePlatform = 'linux-x86_64' | 'macos-arm64';
 
-// Default language server version for downloadable release binaries.
-const DEFAULT_SERVER_VERSION = 'v0.0.2';
-const DEFAULT_CAPNP_CHANNEL = 'v1';
-
 export async function activate(context: ExtensionContext) {
 	if (process.platform === 'win32') {
 		window.showErrorMessage('Windows is not supported by Cap\'n Proto Language Server.');
@@ -63,9 +59,12 @@ export async function activate(context: ExtensionContext) {
 	const config = workspace.getConfiguration('capnp-ls-client');
 	const serverPathRaw = config.get<string>('languageServer.path');
 	const extraEnv = config.get<Record<string, string | number>>('server.extraEnv') || {};
-	// Get server version from configuration or use default
-	const serverVersion = config.get<string>('languageServer.version') || DEFAULT_SERVER_VERSION;
-	const capnpChannel = config.get<string>('languageServer.capnpChannel') || DEFAULT_CAPNP_CHANNEL;
+	const serverVersion = config.get<string>('languageServer.version');
+	const capnpChannel = config.get<string>('languageServer.capnpChannel');
+	if (!serverVersion || !capnpChannel) {
+		window.showErrorMessage('Cap\'n Proto language server version or channel is not configured.');
+		return;
+	}
 
 	// Helper function to resolve environment variables in paths
 	function resolveEnvVars(pathStr: string): string {

--- a/samples/client/src/extension.ts
+++ b/samples/client/src/extension.ts
@@ -19,7 +19,7 @@ let client: LanguageClient;
 type ReleasePlatform = 'linux-x86_64' | 'macos-arm64';
 
 // Default language server version for downloadable release binaries.
-const DEFAULT_SERVER_VERSION = 'v0.0.1';
+const DEFAULT_SERVER_VERSION = 'v0.0.2';
 const DEFAULT_CAPNP_VERSION = '1.2.0';
 
 export async function activate(context: ExtensionContext) {

--- a/samples/client/src/test/runTest.ts
+++ b/samples/client/src/test/runTest.ts
@@ -3,6 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import * as path from 'path';
+import * as fs from 'fs/promises';
+import * as os from 'os';
 
 import { runTests } from '@vscode/test-electron';
 
@@ -19,11 +21,26 @@ async function main() {
 		const testWorkspacePath = path.resolve(__dirname, '../../testFixture');
 		console.log('Test workspace path:', testWorkspacePath);
 
+		const userDataDir = await fs.mkdtemp(path.join(os.tmpdir(), 'capnp-ls-vscode-test-'));
+		const userSettingsDir = path.join(userDataDir, 'User');
+		await fs.mkdir(userSettingsDir, { recursive: true });
+		await fs.writeFile(path.join(userSettingsDir, 'settings.json'), JSON.stringify({
+			'capnp-ls-client.languageServer.path': path.resolve(extensionDevelopmentPath, '../build/capnp-ls'),
+			'capnp-ls-client.languageServer.capnpChannel': 'v1',
+			'capnp-ls-client.server.extraEnv': {
+				CPP_LOG: 'lsp_server=info'
+			}
+		}, null, 2));
+
 		// Download VS Code, unzip it and run the integration test
-		await runTests({ 
-			extensionDevelopmentPath, 
+		await runTests({
+			extensionDevelopmentPath,
 			extensionTestsPath,
-			launchArgs: [testWorkspacePath]
+			launchArgs: [
+				'--user-data-dir',
+				userDataDir,
+				testWorkspacePath
+			]
 		});
 	} catch (err) {
 		console.error('Failed to run tests:', err);

--- a/samples/client/src/test/server.test.ts
+++ b/samples/client/src/test/server.test.ts
@@ -26,13 +26,11 @@ suite('Cap\'n Proto Language Server Test Suite', () => {
         const config = vscode.workspace.getConfiguration('capnp-ls-client');
         console.log('Configuration:', {
             serverPath: config.get('languageServer.path'),
-            capnpVersion: config.get('languageServer.capnpVersion'),
-            importPaths: config.get('compiler.importPaths')
+            capnpChannel: config.get('languageServer.capnpChannel')
         });
 
         assert.ok(config.get('languageServer.path'), 'Language server path is not configured');
-        assert.ok(config.get('languageServer.capnpVersion'), 'Cap\'n Proto linked version is not configured');
-        assert.ok(Array.isArray(config.get('compiler.importPaths')), 'Import paths are not configured');
+        assert.ok(config.get('languageServer.capnpChannel'), 'Cap\'n Proto channel is not configured');
     });
 
     test('Open Document', async () => {

--- a/samples/client/testFixture/.capnp-ls.json
+++ b/samples/client/testFixture/.capnp-ls.json
@@ -1,0 +1,6 @@
+{
+  "importPaths": [
+    "schemas/common",
+    "schemas/common2"
+  ]
+}

--- a/samples/client/testFixture/.vscode/settings.json
+++ b/samples/client/testFixture/.vscode/settings.json
@@ -1,9 +1,5 @@
 {
-    "capnp-ls-client.compiler.importPaths": [
-        "schemas/common",
-        "schemas/common2"
-    ],
-    "capnp-ls-client.languageServer.capnpVersion": "1.2.0",
+    "capnp-ls-client.languageServer.capnpChannel": "v1",
     "capnp-ls-client.languageServer.path": "../build/capnp-ls", // Relative path for development. When using a published extension, specify an absolute path.
     "capnp-ls-client.server.extraEnv": {
         "CPP_LOG": "lsp_server=info"

--- a/samples/client/testFixture/.vscode/settings.json
+++ b/samples/client/testFixture/.vscode/settings.json
@@ -1,7 +1,0 @@
-{
-    "capnp-ls-client.languageServer.capnpChannel": "v1",
-    "capnp-ls-client.languageServer.path": "../build/capnp-ls", // Relative path for development. When using a published extension, specify an absolute path.
-    "capnp-ls-client.server.extraEnv": {
-        "CPP_LOG": "lsp_server=info"
-    }
-}

--- a/samples/package.json
+++ b/samples/package.json
@@ -90,7 +90,7 @@
 	},
 	"scripts": {
 		"vscode:prepublish": "pnpm compile",
-		"compile": "tsc -b",
+		"compile": "tsc -b && esbuild client/src/extension.ts --bundle --platform=node --format=cjs --external:vscode --outfile=client/out/extension.js",
 		"watch": "tsc -b -w",
 		"lint": "eslint ./client/src  --ext .ts,.tsx",
 		"postinstall": "pnpm --dir client install",
@@ -101,11 +101,9 @@
 		"@types/node": "^25.9.2",
 		"@typescript-eslint/eslint-plugin": "^8.60.1",
 		"@typescript-eslint/parser": "^8.60.1",
+		"esbuild": "^0.28.0",
 		"eslint": "^10.4.1",
 		"mocha": "^11.7.6",
 		"typescript": "^6.0.3"
-	},
-	"dependencies": {
-		"vscode-uri": "^3.1.0"
 	}
 }

--- a/samples/package.json
+++ b/samples/package.json
@@ -37,7 +37,7 @@
 				},
 				"capnp-ls-client.languageServer.version": {
 					"type": "string",
-					"default": "v0.0.2",
+					"default": "v0.0.3",
 					"description": "capnp-ls release tag used for automatic Linux x86_64 and macOS arm64 downloads"
 				},
 				"capnp-ls-client.languageServer.capnpChannel": {

--- a/samples/package.json
+++ b/samples/package.json
@@ -3,7 +3,7 @@
 	"description": "A language client of Cap'n Proto Language Server",
 	"author": "Atsushi Tomida",
 	"license": "MIT",
-	"version": "0.1.4",
+	"version": "0.2.0",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/trickstar0301/capnp-ls"
@@ -37,7 +37,7 @@
 				},
 				"capnp-ls-client.languageServer.version": {
 					"type": "string",
-					"default": "v0.0.1",
+					"default": "v0.0.2",
 					"description": "capnp-ls release tag used for automatic Linux x86_64 and macOS arm64 downloads"
 				},
 				"capnp-ls-client.languageServer.capnpVersion": {

--- a/samples/package.json
+++ b/samples/package.json
@@ -40,23 +40,14 @@
 					"default": "v0.0.2",
 					"description": "capnp-ls release tag used for automatic Linux x86_64 and macOS arm64 downloads"
 				},
-				"capnp-ls-client.languageServer.capnpVersion": {
+				"capnp-ls-client.languageServer.capnpChannel": {
 					"type": "string",
 					"enum": [
-						"1.1.0",
-						"1.2.0",
-						"2.0-dev"
+						"v1",
+						"v2"
 					],
-					"default": "1.2.0",
-					"description": "Cap'n Proto compiler version linked into the automatically downloaded language server binary"
-				},
-				"capnp-ls-client.compiler.importPaths": {
-					"type": "array",
-					"items": {
-						"type": "string"
-					},
-					"default": [],
-					"description": "Additional import paths for Cap'n Proto schemas"
+					"default": "v1",
+					"description": "Cap'n Proto compatibility channel for automatically downloaded language server binaries"
 				},
 				"capnp-ls-client.server.extraEnv": {
 					"type": [

--- a/scripts/build-macos-arm64-release.sh
+++ b/scripts/build-macos-arm64-release.sh
@@ -2,12 +2,12 @@
 set -euo pipefail
 
 if [[ $# -ne 2 ]]; then
-  echo "Usage: $0 <capnp-version> <capnp-cxx-source-dir>" >&2
-  echo "Example: $0 1.2.0 ../capnproto/c++" >&2
+  echo "Usage: $0 <capnp-channel> <capnp-cxx-source-dir>" >&2
+  echo "Example: $0 v1 ../capnproto-v1.4.0/c++" >&2
   exit 2
 fi
 
-capnp_version="$1"
+capnp_channel="$1"
 capnp_source_dir="$2"
 
 if [[ "$(uname -s)" != "Darwin" || "$(uname -m)" != "arm64" ]]; then
@@ -22,14 +22,23 @@ if [[ ! -f "${capnp_source_dir}/src/capnp/compiler/compiler.h" ]]; then
 fi
 
 repo_root="$(cd "$(dirname "$0")/.." && pwd)"
-build_dir="${repo_root}/build-release-macos-arm64-capnp-${capnp_version}"
+build_dir="${repo_root}/build-release-macos-arm64-capnp-${capnp_channel}"
 dist_dir="${repo_root}/dist"
-asset_name="capnp-ls-macos-arm64-capnp-${capnp_version}"
+asset_name="capnp-ls-macos-arm64-capnp-${capnp_channel}"
 cxx_standard="17"
 
-if [[ "${capnp_version}" == "2.0-dev" ]]; then
-  cxx_standard="23"
-fi
+case "${capnp_channel}" in
+  v1)
+    cxx_standard="17"
+    ;;
+  v2)
+    cxx_standard="23"
+    ;;
+  *)
+    echo "Unsupported Cap'n Proto channel: ${capnp_channel}. Expected v1 or v2." >&2
+    exit 1
+    ;;
+esac
 
 cmake -B "${build_dir}" \
   -DCMAKE_CXX_STANDARD="${cxx_standard}" \
@@ -43,7 +52,12 @@ ctest --test-dir "${build_dir}" --output-on-failure
 mkdir -p "${dist_dir}"
 cp "${build_dir}/capnp-ls" "${dist_dir}/${asset_name}"
 chmod +x "${dist_dir}/${asset_name}"
+(
+  cd "${dist_dir}"
+  shasum -a 256 "${asset_name}" > "${asset_name}.sha256"
+)
 
 echo "Built ${dist_dir}/${asset_name}"
+echo "Built ${dist_dir}/${asset_name}.sha256"
 echo "Upload manually with:"
-echo "  gh release upload <tag> ${dist_dir}/${asset_name} --clobber"
+echo "  gh release upload <tag> ${dist_dir}/${asset_name} ${dist_dir}/${asset_name}.sha256 --clobber"

--- a/src/compilation_manager.cpp
+++ b/src/compilation_manager.cpp
@@ -4,6 +4,7 @@
 // See LICENSE file in the project root for full license information.
 
 #include "compilation_manager.h"
+#include "kj_compat.h"
 #include <kj/debug.h>
 
 namespace capnp_ls {
@@ -27,7 +28,7 @@ kj::Promise<void> CompilationManager::compile(CompileParams params) {
       return kj::READY_NOW;
     }
 
-    KJ_IF_MAYBE (requestMessage, result.request) {
+    CAPNP_LS_IF_SOME (requestMessage, result.request) {
       auto request =
           (*requestMessage)->getRoot<capnp::schema::CodeGeneratorRequest>();
       SymbolResolver::resolve(

--- a/src/kj_compat.h
+++ b/src/kj_compat.h
@@ -1,0 +1,19 @@
+// Copyright (c) 2024 Atsushi Tomida
+//
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
+
+#pragma once
+
+#include <capnp/common.h>
+#include <kj/common.h>
+
+// Keeps the old KJ_IF_MAYBE pointer-like binding semantics without using the
+// deprecated macro name when building against Cap'n Proto v2.
+#define CAPNP_LS_IF_SOME(name, exp) if (auto name = ::kj::_::readMaybe(exp))
+
+#if CAPNP_VERSION_MAJOR >= 2
+#define CAPNP_LS_NONE kj::none
+#else
+#define CAPNP_LS_NONE nullptr
+#endif

--- a/src/linked_compiler.cpp
+++ b/src/linked_compiler.cpp
@@ -4,6 +4,7 @@
 // See LICENSE file in the project root for full license information.
 
 #include "linked_compiler.h"
+#include "kj_compat.h"
 #include <capnp/compiler/compiler.h>
 #include <capnp/compiler/module-loader.h>
 #include <capnp/schema.capnp.h>
@@ -30,7 +31,7 @@ public:
     hadErrors_ = true;
 
     kj::String filePath;
-    KJ_IF_MAYBE (prefix, directoryPrefixes.find(&directory)) {
+    CAPNP_LS_IF_SOME (prefix, directoryPrefixes.find(&directory)) {
       filePath = kj::str(*prefix, path.toString());
     } else {
       filePath = path.toString();
@@ -93,7 +94,7 @@ kj::Maybe<kj::String> relativeTo(kj::StringPtr fileName, kj::StringPtr baseDir) 
   if (fileName.startsWith(prefix)) {
     return kj::heapString(fileName.slice(prefix.size()));
   }
-  return nullptr;
+  return CAPNP_LS_NONE;
 }
 
 kj::String resolveDirectoryPath(kj::StringPtr path, kj::StringPtr workingDir) {
@@ -134,14 +135,14 @@ kj::Maybe<const kj::ReadableDirectory &> tryOpenDirectory(
   }
 
   auto parsed = parseAbsolutePath(path);
-  KJ_IF_MAYBE (dir, filesystem.getRoot().tryOpenSubdir(parsed)) {
+  CAPNP_LS_IF_SOME (dir, filesystem.getRoot().tryOpenSubdir(parsed)) {
     auto &result = **dir;
     reporter.addDirectoryPrefix(result, withTrailingSlash(path));
     ownedDirectories.add(SourceDirectory{kj::mv(*dir), withTrailingSlash(path)});
     return result;
   }
 
-  return nullptr;
+  return CAPNP_LS_NONE;
 }
 
 bool addRequiredImportPath(
@@ -152,7 +153,7 @@ bool addRequiredImportPath(
     DiagnosticReporter &reporter,
     kj::HashMap<kj::String, kj::Vector<Diagnostic>> &diagnosticMap,
     kj::StringPtr diagnosticFile) {
-  KJ_IF_MAYBE (dir, tryOpenDirectory(
+  CAPNP_LS_IF_SOME (dir, tryOpenDirectory(
                        filesystem, path, ownedDirectories, reporter)) {
     loader.addImportPath(*dir);
     return true;
@@ -171,7 +172,7 @@ void addOptionalImportPath(
     kj::StringPtr path,
     kj::Vector<SourceDirectory> &ownedDirectories,
     DiagnosticReporter &reporter) {
-  KJ_IF_MAYBE (dir, tryOpenDirectory(
+  CAPNP_LS_IF_SOME (dir, tryOpenDirectory(
                        filesystem, path, ownedDirectories, reporter)) {
     loader.addImportPath(*dir);
   }
@@ -222,7 +223,7 @@ LinkedCompileResult LinkedCompiler::compile(
   kj::Vector<SourceDirectory> ownedDirectories;
 
   const kj::ReadableDirectory *workspaceDir = nullptr;
-  KJ_IF_MAYBE (dir, tryOpenDirectory(
+  CAPNP_LS_IF_SOME (dir, tryOpenDirectory(
                        *filesystem, workingDir, ownedDirectories, reporter)) {
     workspaceDir = dir;
   } else {
@@ -258,7 +259,7 @@ LinkedCompileResult LinkedCompiler::compile(
   auto relativeFileName = relativeTo(fileName, workingDir);
   kj::Path sourcePath = parseAbsolutePath(fileName);
   const kj::ReadableDirectory *sourceDir = &filesystem->getRoot();
-  KJ_IF_MAYBE (relative, relativeFileName) {
+  CAPNP_LS_IF_SOME (relative, relativeFileName) {
     sourcePath = kj::Path::parse(*relative);
     sourceDir = workspaceDir;
   }
@@ -266,7 +267,7 @@ LinkedCompileResult LinkedCompiler::compile(
   capnp::compiler::Compiler compiler;
   kj::Vector<SourceFile> sourceFiles;
 
-  KJ_IF_MAYBE (module, loader.loadModule(*sourceDir, sourcePath)) {
+  CAPNP_LS_IF_SOME (module, loader.loadModule(*sourceDir, sourcePath)) {
     auto compiled = compiler.add(*module);
     compiler.eagerlyCompile(
         compiled.getId(),

--- a/src/lsp_message_handler.cpp
+++ b/src/lsp_message_handler.cpp
@@ -4,7 +4,9 @@
 // See LICENSE file in the project root for full license information.
 
 #include "lsp_message_handler.h"
+#include "kj_compat.h"
 #include "lsp_types.h"
+#include "project_config.h"
 #include <capnp/compat/json.h>
 #include <capnp/message.h>
 #include <iostream>
@@ -25,7 +27,7 @@ LspMessageHandler::LspMessageHandler(
 kj::Promise<void>
 LspMessageHandler::handleMessage(kj::Maybe<kj::String> maybeMessage) {
   try {
-    KJ_IF_MAYBE (message, maybeMessage) {
+    CAPNP_LS_IF_SOME (message, maybeMessage) {
       const char *headerEnd = strstr(message->begin(), LSP_HEADER_DELIMITER);
       if (!headerEnd) {
         KJ_LOG(ERROR, "Invalid message format: no header delimiter found");
@@ -68,7 +70,7 @@ LspMessageHandler::handleMessage(kj::Maybe<kj::String> maybeMessage) {
       auto responseMessageBuilder = kj::heap<capnp::MallocMessageBuilder>();
       kj::Promise<void> promise = kj::READY_NOW;
 
-      KJ_IF_MAYBE (methodEnum, tryParseLspMethod(method)) {
+      CAPNP_LS_IF_SOME (methodEnum, tryParseLspMethod(method)) {
         switch (*methodEnum) {
         case LspMethod::INITIALIZE:
           promise = handleInitialize(params, *responseMessageBuilder);
@@ -101,13 +103,13 @@ LspMessageHandler::handleMessage(kj::Maybe<kj::String> maybeMessage) {
         KJ_LOG(ERROR, "Unknown method", method.cStr());
       }
 
-      KJ_IF_MAYBE (requestId, maybeRequestId) {
+      CAPNP_LS_IF_SOME (requestId, maybeRequestId) {
         return promise.then(
             [this,
              id = *requestId,
              builder = kj::mv(responseMessageBuilder)]() mutable {
               auto response = builder->getRoot<capnp::JsonValue>().asReader();
-              KJ_IF_MAYBE (responseString, buildResponseString(id, response)) {
+              CAPNP_LS_IF_SOME (responseString, buildResponseString(id, response)) {
                 (void)stdoutWriter.write(*responseString);
               }
               return kj::Promise<void>(kj::READY_NOW);
@@ -124,6 +126,49 @@ LspMessageHandler::handleMessage(kj::Maybe<kj::String> maybeMessage) {
     KJ_LOG(ERROR, "Error processing message", e.what());
   }
   return kj::Promise<void>(kj::READY_NOW);
+}
+
+void LspMessageHandler::clearCompilationState() {
+  fileSourceInfoMap.clear();
+  nodeLocationMap.clear();
+  diagnosticMap.clear();
+}
+
+bool LspMessageHandler::isProjectConfigPath(kj::StringPtr path) {
+  return path.endsWith(kj::str("/", PROJECT_CONFIG_FILE)) ||
+      path == PROJECT_CONFIG_FILE;
+}
+
+bool LspMessageHandler::reloadProjectConfig() {
+  if (importPathsConfiguredByInitialization) {
+    KJ_LOG(INFO, "Skipping project config reload because initialization options configured import paths");
+    return false;
+  }
+  if (workspacePath.size() == 0) {
+    KJ_LOG(INFO, "Skipping project config reload because workspace path is not set");
+    return false;
+  }
+
+  kj::Vector<kj::String> loadedImportPaths;
+  if (loadProjectConfigImportPaths(workspacePath, loadedImportPaths)) {
+    importPaths.clear();
+    for (auto &path : loadedImportPaths) {
+      importPaths.add(kj::mv(path));
+    }
+    clearCompilationState();
+    KJ_LOG(INFO, "Project config reloaded");
+    return true;
+  }
+
+  if (!projectConfigExists(workspacePath)) {
+    importPaths.clear();
+    clearCompilationState();
+    KJ_LOG(INFO, "Project config removed; import paths cleared");
+    return true;
+  }
+
+  KJ_LOG(ERROR, "Keeping previous project config because reload failed");
+  return false;
 }
 
 kj::Maybe<kj::String> LspMessageHandler::buildResponseString(
@@ -160,7 +205,7 @@ kj::Maybe<kj::String> LspMessageHandler::buildResponseString(
         responseStr);
   } catch (kj::Exception &e) {
     KJ_LOG(ERROR, "Error building response string", e.getDescription());
-    return nullptr;
+    return CAPNP_LS_NONE;
   }
 }
 
@@ -358,7 +403,7 @@ kj::Promise<void> LspMessageHandler::handleDefinition(
         line,
         character);
 
-    KJ_IF_MAYBE (rangeMap, fileSourceInfoMap.find(strippedUri)) {
+    CAPNP_LS_IF_SOME (rangeMap, fileSourceInfoMap.find(strippedUri)) {
       for (const auto &[range, id] : *rangeMap) {
         if (range.start.line <= line && line <= range.end.line &&
             range.start.character <= character &&
@@ -366,7 +411,7 @@ kj::Promise<void> LspMessageHandler::handleDefinition(
 
           KJ_LOG(INFO, "Found range for ", id);
 
-          KJ_IF_MAYBE (location, nodeLocationMap.find(id)) {
+          CAPNP_LS_IF_SOME (location, nodeLocationMap.find(id)) {
             KJ_LOG(INFO, "Found location");
 
             auto locationObj = resultField.getValue().initObject(2);
@@ -441,6 +486,12 @@ kj::Promise<void> LspMessageHandler::handleDidChangeWatchedFiles(
               auto uri = kj::heapString(changeField.getValue().getString());
               KJ_LOG(INFO, "URI", uri.cStr());
 
+              auto path = uriToPath(uri);
+              if (isProjectConfigPath(path)) {
+                reloadProjectConfig();
+                return kj::READY_NOW;
+              }
+
               return compileCapnpFile(uri);
             }
           }
@@ -492,8 +543,9 @@ kj::Promise<void> LspMessageHandler::handleInitialize(
     auto paramsObj = params.getObject();
     for (auto field : paramsObj) {
       if (field.getName() == "workspaceFolders") {
-        auto folders = field.getValue().getArray();
-        if (folders.size() > 0) {
+        if (field.getValue().isArray()) {
+          auto folders = field.getValue().getArray();
+          if (folders.size() > 0) {
           auto firstFolder = folders[0].getObject();
           for (auto folderField : firstFolder) {
             if (folderField.getName() == "uri") {
@@ -502,6 +554,17 @@ kj::Promise<void> LspMessageHandler::handleInitialize(
               KJ_LOG(INFO, "Workspace path set to", workspacePath);
             }
           }
+          }
+        }
+      } else if (field.getName() == "rootUri" && workspacePath.size() == 0) {
+        if (!field.getValue().isNull()) {
+          workspacePath = uriToPath(field.getValue().getString());
+          KJ_LOG(INFO, "Workspace path set from rootUri", workspacePath);
+        }
+      } else if (field.getName() == "rootPath" && workspacePath.size() == 0) {
+        if (!field.getValue().isNull()) {
+          workspacePath = kj::heapString(kj::StringPtr(field.getValue().getString()));
+          KJ_LOG(INFO, "Workspace path set from rootPath", workspacePath);
         }
       } else if (field.getName() == "initializationOptions") {
         auto initOptions = field.getValue().getObject();
@@ -514,6 +577,7 @@ kj::Promise<void> LspMessageHandler::handleInitialize(
                 for (auto path : paths) {
                   importPaths.add(kj::heapString(path.getString()));
                 }
+                importPathsConfiguredByInitialization = true;
                 KJ_LOG(INFO, "Import paths configured");
               }
             }
@@ -521,6 +585,7 @@ kj::Promise<void> LspMessageHandler::handleInitialize(
         }
       }
     }
+    reloadProjectConfig();
   } catch (kj::Exception &e) {
     KJ_LOG(ERROR, "Error processing initialize params", e.getDescription());
   }

--- a/src/lsp_message_handler.h
+++ b/src/lsp_message_handler.h
@@ -23,6 +23,25 @@ class LspMessageHandler {
 public:
   LspMessageHandler(ServerContext &serverContext, StdoutWriter &stdoutWriter);
   kj::Promise<void> handleMessage(kj::Maybe<kj::String> message);
+#ifdef CAPNP_LS_TESTING
+  kj::Promise<void> testHandleInitialize(
+      const capnp::JsonValue::Reader &params,
+      capnp::MallocMessageBuilder &initializeResponseBuilder) {
+    return handleInitialize(params, initializeResponseBuilder);
+  }
+  size_t testImportPathCount() const {
+    return importPaths.size();
+  }
+  kj::StringPtr testImportPath(size_t index) const {
+    return importPaths[index];
+  }
+  kj::StringPtr testWorkspacePath() const {
+    return workspacePath;
+  }
+  bool testReloadProjectConfig() {
+    return reloadProjectConfig();
+  }
+#endif
 
 private:
   kj::Maybe<kj::String>
@@ -43,12 +62,16 @@ private:
       const capnp::JsonValue::Reader &params,
       capnp::MallocMessageBuilder &formattingResponseBuilder);
   kj::Promise<void> publishDiagnostics(kj::StringPtr fileName);
+  bool reloadProjectConfig();
+  void clearCompilationState();
+  bool isProjectConfigPath(kj::StringPtr path);
 
   kj::HashMap<kj::String, kj::HashMap<Range, uint64_t>> fileSourceInfoMap;
   kj::HashMap<uint64_t, kj::Own<Location>> nodeLocationMap;
   kj::HashMap<kj::String, kj::Vector<Diagnostic>> diagnosticMap;
   kj::String workspacePath;
   kj::Vector<kj::String> importPaths;
+  bool importPathsConfiguredByInitialization = false;
   ServerContext &context;
   kj::Own<CompilationManager> compilationManager;
   StdoutWriter &stdoutWriter;

--- a/src/lsp_types.cpp
+++ b/src/lsp_types.cpp
@@ -4,6 +4,7 @@
 // See LICENSE file in the project root for full license information.
 
 #include "lsp_types.h"
+#include "kj_compat.h"
 
 namespace capnp_ls {
 
@@ -25,6 +26,6 @@ kj::Maybe<LspMethod> tryParseLspMethod(kj::StringPtr name) {
     LSP_FOR_EACH_METHOD(TRY_METHOD)
 #undef TRY_METHOD
     
-    return nullptr;
+    return CAPNP_LS_NONE;
 }
 } // namespace capnp_ls

--- a/src/project_config.cpp
+++ b/src/project_config.cpp
@@ -1,0 +1,75 @@
+// Copyright (c) 2024 Atsushi Tomida
+//
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
+
+#include "project_config.h"
+
+#include <capnp/compat/json.h>
+#include <capnp/message.h>
+#include <fstream>
+#include <iterator>
+#include <kj/debug.h>
+
+namespace capnp_ls {
+
+namespace {
+
+kj::String projectConfigPath(kj::StringPtr workspacePath) {
+  return kj::str(workspacePath, "/", PROJECT_CONFIG_FILE);
+}
+
+} // namespace
+
+void parseProjectConfigImportPaths(
+    kj::StringPtr content,
+    kj::Vector<kj::String> &importPaths) {
+  capnp::JsonCodec codec;
+  capnp::MallocMessageBuilder messageBuilder;
+  auto root = messageBuilder.initRoot<capnp::JsonValue>();
+  kj::ArrayPtr<const char> jsonContent(content.begin(), content.size());
+  codec.decodeRaw(jsonContent, root);
+
+  auto config = root.getObject();
+  for (auto field : config) {
+    if (field.getName().asString() == kj::StringPtr("importPaths")) {
+      auto paths = field.getValue().getArray();
+      for (auto path : paths) {
+        importPaths.add(kj::heapString(kj::StringPtr(path.getString())));
+      }
+    }
+  }
+}
+
+bool loadProjectConfigImportPaths(
+    kj::StringPtr workspacePath,
+    kj::Vector<kj::String> &importPaths) {
+  auto configPath = projectConfigPath(workspacePath);
+  std::ifstream input(configPath.cStr());
+  if (!input.good()) {
+    KJ_LOG(INFO, "Project config not found", configPath);
+    return false;
+  }
+
+  std::string content(
+      (std::istreambuf_iterator<char>(input)),
+      std::istreambuf_iterator<char>());
+
+  try {
+    parseProjectConfigImportPaths(kj::StringPtr(content.data(), content.size()), importPaths);
+  } catch (kj::Exception &e) {
+    KJ_LOG(ERROR, "Failed to parse project config", configPath, e.getDescription());
+    return false;
+  }
+
+  KJ_LOG(INFO, "Loaded project config", configPath);
+  return true;
+}
+
+bool projectConfigExists(kj::StringPtr workspacePath) {
+  auto configPath = projectConfigPath(workspacePath);
+  std::ifstream input(configPath.cStr());
+  return input.good();
+}
+
+} // namespace capnp_ls

--- a/src/project_config.h
+++ b/src/project_config.h
@@ -1,0 +1,25 @@
+// Copyright (c) 2024 Atsushi Tomida
+//
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
+
+#pragma once
+
+#include <kj/string.h>
+#include <kj/vector.h>
+
+namespace capnp_ls {
+
+constexpr const char *PROJECT_CONFIG_FILE = ".capnp-ls.json";
+
+void parseProjectConfigImportPaths(
+    kj::StringPtr content,
+    kj::Vector<kj::String> &importPaths);
+
+bool loadProjectConfigImportPaths(
+    kj::StringPtr workspacePath,
+    kj::Vector<kj::String> &importPaths);
+
+bool projectConfigExists(kj::StringPtr workspacePath);
+
+} // namespace capnp_ls

--- a/src/stdin_reader.cpp
+++ b/src/stdin_reader.cpp
@@ -4,6 +4,7 @@
 // See LICENSE file in the project root for full license information.
 
 #include "stdin_reader.h"
+#include "kj_compat.h"
 #include <cstdlib>
 
 namespace capnp_ls {
@@ -17,7 +18,7 @@ parseNextMessage(const char *buffer, size_t currentPos, size_t processedPos) {
   // Find the end of the header
   const char *headerEnd = strstr(buffer + processedPos, LSP_HEADER_DELIMITER);
   if (!headerEnd) {
-    return {processedPos, nullptr};
+    return {processedPos, CAPNP_LS_NONE};
   }
 
   // Parse Content-Length
@@ -26,7 +27,7 @@ parseNextMessage(const char *buffer, size_t currentPos, size_t processedPos) {
   if (!contentLengthStr) {
     return {
         static_cast<size_t>(headerEnd - buffer + LSP_HEADER_DELIMITER_SIZE),
-        nullptr};
+        CAPNP_LS_NONE};
   }
 
   size_t contentLength = strtoul(
@@ -38,7 +39,7 @@ parseNextMessage(const char *buffer, size_t currentPos, size_t processedPos) {
   size_t totalMessageSize = headerSize + contentLength;
 
   if (currentPos - processedPos < totalMessageSize) {
-    return {processedPos, nullptr};
+    return {processedPos, CAPNP_LS_NONE};
   }
 
   return {
@@ -51,7 +52,7 @@ kj::Promise<void> StdinReader::monitorStdin() {
       .then([this](size_t n) {
         if (n == 0) {
           KJ_LOG(INFO, "EOF detected on stdin");
-          tasks.add(handler.handleMessage(kj::Maybe<kj::String>(nullptr)));
+          tasks.add(handler.handleMessage(kj::Maybe<kj::String>(CAPNP_LS_NONE)));
           return kj::Promise<void>(kj::READY_NOW);
         }
 
@@ -62,7 +63,7 @@ kj::Promise<void> StdinReader::monitorStdin() {
           auto result = parseNextMessage(buffer, currentPos, processedPos);
           processedPos = result.processedSize;
 
-          KJ_IF_MAYBE (content, result.content) {
+          CAPNP_LS_IF_SOME (content, result.content) {
             tasks.add(handler.handleMessage(kj::mv(*content)));
           } else {
             break;

--- a/src/symbol_resolver.cpp
+++ b/src/symbol_resolver.cpp
@@ -4,6 +4,7 @@
 // See LICENSE file in the project root for full license information.
 
 #include "symbol_resolver.h"
+#include "kj_compat.h"
 #include "logger.h"
 #include <capnp/message.h>
 #include <capnp/schema-loader.h>
@@ -72,7 +73,7 @@ kj::String extractFilePath(
   KJ_LOG(INFO, "extractFilePath: ", displayName);
   auto colonPos = displayName.findFirst(':');
   kj::String relativeFilePathString;
-  KJ_IF_MAYBE (pos, colonPos) {
+  CAPNP_LS_IF_SOME (pos, colonPos) {
     relativeFilePathString = kj::heapString(displayName.slice(0, *pos));
   } else {
     relativeFilePathString = kj::heapString(displayName);
@@ -113,7 +114,7 @@ kj::String extractFilePath(
       }
     }
 
-    return nullptr;
+    return CAPNP_LS_NONE;
   };
 
   auto workspaceFilePath = workspaceRelativePath.eval(relativeFilePathString);
@@ -128,12 +129,12 @@ kj::String extractFilePath(
   } else {
     // Try import paths
     for (const auto &importPath : importPaths) {
-      KJ_IF_MAYBE (filePath, findInImportPath(importPath)) {
+      CAPNP_LS_IF_SOME (filePath, findInImportPath(importPath)) {
         return kj::mv(*filePath);
       }
     }
 
-    KJ_IF_MAYBE (
+    CAPNP_LS_IF_SOME (
         filePath,
         findInImportPath(kj::str(CAPNP_LS_CAPNP_SOURCE_DIR, "/src"))) {
       return kj::mv(*filePath);
@@ -176,7 +177,7 @@ int SymbolResolver::resolve(
     int depth = 1;
     for (auto node : request.getNodes()) {
       if (node.which() == capnp::schema::Node::Which::FILE) {
-        KJ_IF_MAYBE (sourceInfo, fileSourceInfoMap.find(node.getId())) {
+        CAPNP_LS_IF_SOME (sourceInfo, fileSourceInfoMap.find(node.getId())) {
           kj::String filePath = extractFilePath(
               node.getDisplayName(), importPaths, workspacePath);
           // clear previous data for this file
@@ -214,7 +215,7 @@ int SymbolResolver::resolve(
       kj::String filePath =
           extractFilePath(displayName, importPaths, workspacePath);
 
-      KJ_IF_MAYBE (sourceInfo, sourceInfoMap.find(node.getId())) {
+      CAPNP_LS_IF_SOME (sourceInfo, sourceInfoMap.find(node.getId())) {
         Range range{
             getPositionInFile(filePath, sourceInfo->getStartByte()),
             getPositionInFile(filePath, sourceInfo->getEndByte())};

--- a/tests/initialize_config_test.cpp
+++ b/tests/initialize_config_test.cpp
@@ -1,0 +1,157 @@
+// Copyright (c) 2024 Atsushi Tomida
+//
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
+
+#include "lsp_message_handler.h"
+#include "stdout_writer.h"
+#include <capnp/common.h>
+#include <capnp/compat/json.h>
+#include <capnp/message.h>
+#include <filesystem>
+#include <fstream>
+#include <kj/async-io.h>
+#include <kj/debug.h>
+#include <unistd.h>
+
+namespace {
+
+class NullOutputStream final : public kj::AsyncOutputStream {
+public:
+#if CAPNP_VERSION_MAJOR >= 2
+  kj::Promise<void> write(kj::ArrayPtr<const kj::byte> buffer) override {
+    return kj::READY_NOW;
+  }
+#else
+  kj::Promise<void> write(const void *buffer, size_t size) override {
+    return kj::READY_NOW;
+  }
+#endif
+
+  kj::Promise<void>
+  write(kj::ArrayPtr<const kj::ArrayPtr<const kj::byte>> pieces) override {
+    return kj::READY_NOW;
+  }
+
+  kj::Promise<void> whenWriteDisconnected() override {
+    return kj::NEVER_DONE;
+  }
+};
+
+void require(bool condition, kj::StringPtr message) {
+  if (!condition) {
+    KJ_FAIL_REQUIRE(message);
+  }
+}
+
+std::filesystem::path makeTempWorkspace() {
+  auto path = std::filesystem::temp_directory_path() /
+      kj::str("capnp-ls-initialize-config-test-", getpid()).cStr();
+  std::filesystem::remove_all(path);
+  std::filesystem::create_directories(path);
+  return path;
+}
+
+void writeConfig(const std::filesystem::path &workspace, kj::StringPtr content) {
+  std::ofstream output(workspace / ".capnp-ls.json");
+  output.write(content.begin(), content.size());
+}
+
+void decodeJson(kj::StringPtr json, capnp::MallocMessageBuilder &builder) {
+  capnp::JsonCodec codec;
+  auto root = builder.initRoot<capnp::JsonValue>();
+  codec.decodeRaw(kj::arrayPtr(json.begin(), json.size()), root);
+}
+
+} // namespace
+
+int main() {
+  auto io = kj::setupAsyncIo();
+  auto paf = kj::newPromiseAndFulfiller<void>();
+  capnp_ls::ServerContext context(io, kj::mv(paf.fulfiller));
+
+  {
+    capnp_ls::StdoutWriter writer(kj::heap<NullOutputStream>());
+    capnp_ls::LspMessageHandler handler(context, writer);
+    capnp::MallocMessageBuilder params;
+    decodeJson(kj::str(
+        R"({"workspaceFolders":null,"rootUri":"file://)",
+        CAPNP_LS_TEST_FIXTURE_DIR,
+        R"("})"),
+        params);
+    capnp::MallocMessageBuilder response;
+    handler
+        .testHandleInitialize(params.getRoot<capnp::JsonValue>().asReader(), response)
+        .wait(io.waitScope);
+    require(
+        handler.testWorkspacePath() == CAPNP_LS_TEST_FIXTURE_DIR,
+        "rootUri should be used when workspaceFolders is null");
+    require(
+        handler.testImportPathCount() == 2,
+        "rootUri initialize should load .capnp-ls.json import paths");
+  }
+
+  {
+    auto workspace = makeTempWorkspace();
+    KJ_DEFER(std::filesystem::remove_all(workspace));
+    writeConfig(workspace, R"({"importPaths":["one"]})");
+
+    capnp_ls::StdoutWriter writer(kj::heap<NullOutputStream>());
+    capnp_ls::LspMessageHandler handler(context, writer);
+    capnp::MallocMessageBuilder params;
+    auto workspaceString = workspace.string();
+    decodeJson(kj::str(
+        R"({"workspaceFolders":[{"uri":"file://)",
+        workspaceString.c_str(),
+        R"("}]})"),
+        params);
+    capnp::MallocMessageBuilder response;
+    handler
+        .testHandleInitialize(params.getRoot<capnp::JsonValue>().asReader(), response)
+        .wait(io.waitScope);
+    require(
+        handler.testImportPathCount() == 1 && handler.testImportPath(0) == "one",
+        "initial import path should load from project config");
+
+    writeConfig(workspace, R"({"importPaths":["two","three"]})");
+    require(handler.testReloadProjectConfig(), "valid config change should reload");
+    require(
+        handler.testImportPathCount() == 2 && handler.testImportPath(0) == "two",
+        "changed project config should replace import paths");
+
+    writeConfig(workspace, R"({"importPaths":[)");
+    require(!handler.testReloadProjectConfig(), "invalid config should not reload");
+    require(
+        handler.testImportPathCount() == 2 && handler.testImportPath(0) == "two",
+        "invalid project config should keep previous import paths");
+
+    std::filesystem::remove(workspace / ".capnp-ls.json");
+    require(handler.testReloadProjectConfig(), "deleted config should reload");
+    require(
+        handler.testImportPathCount() == 0,
+        "deleted project config should clear import paths");
+  }
+
+  {
+    capnp_ls::StdoutWriter writer(kj::heap<NullOutputStream>());
+    capnp_ls::LspMessageHandler handler(context, writer);
+    capnp::MallocMessageBuilder params;
+    decodeJson(kj::str(
+        R"({"workspaceFolders":[{"uri":"file://)",
+        CAPNP_LS_TEST_FIXTURE_DIR,
+        R"("}],"initializationOptions":{"capnp":{"importPaths":["override"]}}})"),
+        params);
+    capnp::MallocMessageBuilder response;
+    handler
+        .testHandleInitialize(params.getRoot<capnp::JsonValue>().asReader(), response)
+        .wait(io.waitScope);
+    require(
+        handler.testImportPathCount() == 1,
+        "initialization options should override .capnp-ls.json");
+    require(
+        handler.testImportPath(0) == "override",
+        "initialization option import path should be preserved");
+  }
+
+  return 0;
+}

--- a/tests/install_sh_test.sh
+++ b/tests/install_sh_test.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env sh
+set -eu
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+tmp_root="$(mktemp -d)"
+trap 'rm -rf "$tmp_root"' EXIT
+
+fail() {
+  echo "install_sh_test: $*" >&2
+  exit 1
+}
+
+write_asset() {
+  asset_dir="$1"
+  asset_name="$2"
+  mkdir -p "$asset_dir"
+  printf '#!/usr/bin/env sh\nprintf "capnp-ls test binary\\n"\n' > "$asset_dir/$asset_name"
+  chmod +x "$asset_dir/$asset_name"
+  if command -v sha256sum >/dev/null 2>&1; then
+    (cd "$asset_dir" && sha256sum "$asset_name" > "$asset_name.sha256")
+  else
+    (cd "$asset_dir" && shasum -a 256 "$asset_name" > "$asset_name.sha256")
+  fi
+}
+
+asset_name="capnp-ls-linux-x86_64-capnp-v1"
+v2_asset_name="capnp-ls-linux-x86_64-capnp-v2"
+release_dir="$tmp_root/releases/v9.9.9"
+install_dir="$tmp_root/bin"
+write_asset "$release_dir" "$asset_name"
+write_asset "$release_dir" "$v2_asset_name"
+
+CAPNP_LS_VERSION="v9.9.9" \
+CAPNP_LS_INSTALL_DIR="$install_dir" \
+CAPNP_LS_DOWNLOAD_BASE_URL="file://$tmp_root/releases" \
+CAPNP_LS_OS="linux" \
+CAPNP_LS_ARCH="x86_64" \
+  sh "$repo_root/install.sh"
+
+[ -x "$install_dir/capnp-ls" ] || fail "expected installed capnp-ls to be executable"
+"$install_dir/capnp-ls" | grep -q "capnp-ls test binary" || fail "installed binary did not run"
+
+bad_release_dir="$tmp_root/releases/v9.9.10"
+write_asset "$bad_release_dir" "$asset_name"
+printf '0000000000000000000000000000000000000000000000000000000000000000  %s\n' "$asset_name" > "$bad_release_dir/$asset_name.sha256"
+
+if CAPNP_LS_VERSION="v9.9.10" \
+  CAPNP_LS_INSTALL_DIR="$tmp_root/bad-bin" \
+  CAPNP_LS_DOWNLOAD_BASE_URL="file://$tmp_root/releases" \
+  CAPNP_LS_OS="linux" \
+  CAPNP_LS_ARCH="x86_64" \
+    sh "$repo_root/install.sh" >/dev/null 2>&1; then
+  fail "expected checksum mismatch to fail"
+fi
+
+if CAPNP_LS_VERSION="v9.9.9" \
+  CAPNP_LS_INSTALL_DIR="$tmp_root/unsupported-bin" \
+  CAPNP_LS_DOWNLOAD_BASE_URL="file://$tmp_root/releases" \
+  CAPNP_LS_OS="linux" \
+  CAPNP_LS_ARCH="arm64" \
+    sh "$repo_root/install.sh" >/dev/null 2>&1; then
+  fail "expected unsupported release platform to fail"
+fi
+
+CAPNP_LS_VERSION="v9.9.9" \
+CAPNP_LS_INSTALL_DIR="$tmp_root/compat-bin" \
+CAPNP_LS_DOWNLOAD_BASE_URL="file://$tmp_root/releases" \
+CAPNP_LS_OS="linux" \
+CAPNP_LS_ARCH="x86_64" \
+CAPNP_LS_CAPNP_VERSION="1.4.0" \
+  sh "$repo_root/install.sh" >/dev/null
+
+[ -x "$tmp_root/compat-bin/capnp-ls" ] || fail "expected 1.4.0 alias to install capnp-v1 asset"
+
+CAPNP_LS_VERSION="v9.9.9" \
+CAPNP_LS_INSTALL_DIR="$tmp_root/v2-bin" \
+CAPNP_LS_DOWNLOAD_BASE_URL="file://$tmp_root/releases" \
+CAPNP_LS_OS="linux" \
+CAPNP_LS_ARCH="x86_64" \
+CAPNP_LS_CAPNP_VERSION="2.0-dev" \
+  sh "$repo_root/install.sh" >/dev/null
+
+[ -x "$tmp_root/v2-bin/capnp-ls" ] || fail "expected 2.0-dev alias to install capnp-v2 asset"
+
+echo "install_sh_test: ok"

--- a/tests/linked_compiler_test.cpp
+++ b/tests/linked_compiler_test.cpp
@@ -4,6 +4,8 @@
 // See LICENSE file in the project root for full license information.
 
 #include "linked_compiler.h"
+#include "kj_compat.h"
+#include "project_config.h"
 #include "symbol_resolver.h"
 #include <capnp/schema.capnp.h>
 #include <kj/debug.h>
@@ -25,7 +27,7 @@ uint64_t resolveAt(
     const kj::HashMap<capnp_ls::Range, uint64_t> &rangeMap,
     uint32_t line,
     uint32_t character) {
-  kj::Maybe<uint64_t> resolvedId = nullptr;
+  kj::Maybe<uint64_t> resolvedId = CAPNP_LS_NONE;
   for (const auto &[range, id] : rangeMap) {
     if (range.start.line <= line && line <= range.end.line &&
         range.start.character <= character && character <= range.end.character) {
@@ -57,7 +59,31 @@ int main() {
   kj::Vector<kj::String> importPaths;
   importPaths.add(kj::heapString("schemas/common"));
 
+  kj::Vector<kj::String> configuredImportPaths;
+  require(
+      capnp_ls::loadProjectConfigImportPaths(
+          CAPNP_LS_TEST_FIXTURE_DIR,
+          configuredImportPaths),
+      "project config should load from fixture");
+  require(
+      configuredImportPaths.size() == 2,
+      "project config should include two import paths");
+  require(
+      configuredImportPaths[0] == "schemas/common",
+      "project config should preserve import path order");
+
   kj::HashMap<kj::String, kj::Vector<capnp_ls::Diagnostic>> diagnostics;
+
+  auto configuredResult = capnp_ls::LinkedCompiler::compile(
+      fixturePath("schemas/company.capnp"),
+      CAPNP_LS_TEST_FIXTURE_DIR,
+      configuredImportPaths,
+      diagnostics);
+  require(configuredResult.success, "project config import paths should compile");
+  require(
+      diagnostics.size() == 0,
+      "project config import paths should not produce diagnostics");
+  diagnostics.clear();
 
   auto validResult = capnp_ls::LinkedCompiler::compile(
       fixturePath("schemas/company.capnp"),


### PR DESCRIPTION
## Summary
- add curl/wget install support with release asset checksum verification
- switch release artifacts to capnp-v1 and capnp-v2 channels while testing the v1 channel against Cap'n Proto v1.4.0 and the v2 channel against Cap'n Proto v2
- load project-specific import paths from .capnp-ls.json and reload them on watched file changes
- update the VS Code client for .capnp-ls.json, capnpChannel, release downloads, and checksum verification
- remove deprecated KJ_IF_MAYBE usage through a compatibility wrapper

## Verification
- just test
- just test-install
- pnpm --dir samples compile
- pnpm --dir samples test
- ctest --test-dir build-capnp-v1.1.0-cxx17 --output-on-failure
- git diff --check