### PR TITLE
Stop advertising unsupported completion provider

### DIFF
--- a/src/lsp_message_handler.cpp
+++ b/src/lsp_message_handler.cpp
@@ -599,7 +599,7 @@ kj::Promise<void> LspMessageHandler::handleInitialize(
   auto capsField = resultValue[0];
   capsField.setName("capabilities");
 
-  auto capabilities = capsField.getValue().initObject(4);
+  auto capabilities = capsField.getValue().initObject(3);
 
   // Set text document sync capability
   auto syncField = capabilities[0];
@@ -623,13 +623,8 @@ kj::Promise<void> LspMessageHandler::handleInitialize(
   defField.setName("definitionProvider");
   defField.getValue().setBoolean(true);
 
-  // Set completion provider capability
-  auto compField = capabilities[2];
-  compField.setName("completionProvider");
-  compField.getValue().setBoolean(true);
-
   // Set workspace/didChangeWatchedFiles capability
-  auto watchedFilesField = capabilities[3];
+  auto watchedFilesField = capabilities[2];
   watchedFilesField.setName("workspace/didChangeWatchedFiles");
   watchedFilesField.getValue().setBoolean(true);
 

--- a/tests/initialize_config_test.cpp
+++ b/tests/initialize_config_test.cpp
@@ -63,6 +63,34 @@ void decodeJson(kj::StringPtr json, capnp::MallocMessageBuilder &builder) {
   codec.decodeRaw(kj::arrayPtr(json.begin(), json.size()), root);
 }
 
+bool hasObjectField(
+    const capnp::JsonValue::Reader &value,
+    kj::StringPtr fieldName) {
+  if (!value.isObject()) {
+    return false;
+  }
+
+  for (auto field : value.getObject()) {
+    if (field.getName() == fieldName) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+capnp::JsonValue::Reader getObjectField(
+    const capnp::JsonValue::Reader &value,
+    kj::StringPtr fieldName) {
+  for (auto field : value.getObject()) {
+    if (field.getName() == fieldName) {
+      return field.getValue();
+    }
+  }
+
+  KJ_FAIL_REQUIRE("missing field", fieldName);
+}
+
 } // namespace
 
 int main() {
@@ -89,6 +117,13 @@ int main() {
     require(
         handler.testImportPathCount() == 2,
         "rootUri initialize should load .capnp-ls.json import paths");
+
+    auto responseRoot = response.getRoot<capnp::JsonValue>().asReader();
+    auto result = getObjectField(responseRoot, "result");
+    auto capabilities = getObjectField(result, "capabilities");
+    require(
+        !hasObjectField(capabilities, "completionProvider"),
+        "initialize should not advertise completion without a completion handler");
   }
 
   {


### PR DESCRIPTION
## Summary
- remove the unsupported completionProvider capability from initialize responses
- add a regression check that initialize does not advertise completion without a handler

## Test
- just test