### PR TITLE
Return method-not-found for unsupported LSP requests

### DIFF
--- a/src/lsp_message_handler.cpp
+++ b/src/lsp_message_handler.cpp
@@ -100,7 +100,15 @@ LspMessageHandler::handleMessage(kj::Maybe<kj::String> maybeMessage) {
           break;
         }
       } else {
-        KJ_LOG(ERROR, "Unknown method", method.cStr());
+        KJ_LOG(INFO, "Unsupported method", method.cStr());
+        CAPNP_LS_IF_SOME (requestId, maybeRequestId) {
+          CAPNP_LS_IF_SOME (
+              responseString,
+              buildErrorResponseString(*requestId, -32601, "Method not found")) {
+            (void)stdoutWriter.write(*responseString);
+          }
+          return kj::READY_NOW;
+        }
       }
 
       CAPNP_LS_IF_SOME (requestId, maybeRequestId) {
@@ -205,6 +213,45 @@ kj::Maybe<kj::String> LspMessageHandler::buildResponseString(
         responseStr);
   } catch (kj::Exception &e) {
     KJ_LOG(ERROR, "Error building response string", e.getDescription());
+    return CAPNP_LS_NONE;
+  }
+}
+
+kj::Maybe<kj::String> LspMessageHandler::buildErrorResponseString(
+    const double id,
+    int code,
+    kj::StringPtr message) {
+  try {
+    capnp::MallocMessageBuilder messageBuilder;
+    auto root = messageBuilder.initRoot<capnp::JsonValue>();
+    auto obj = root.initObject(3);
+
+    obj[0].setName(LSP_JSONRPC);
+    obj[0].getValue().setString(LSP_JSON_RPC_VERSION);
+
+    obj[1].setName(LSP_ID);
+    obj[1].getValue().setNumber(id);
+
+    obj[2].setName(LSP_ERROR);
+    auto error = obj[2].getValue().initObject(2);
+
+    error[0].setName("code");
+    error[0].getValue().setNumber(code);
+
+    error[1].setName("message");
+    error[1].getValue().setString(message);
+
+    capnp::JsonCodec codec;
+    kj::String responseStr =
+        codec.encodeRaw(messageBuilder.getRoot<capnp::JsonValue>());
+
+    return kj::str(
+        LSP_CONTENT_LENGTH_HEADER,
+        responseStr.size(),
+        LSP_HEADER_DELIMITER,
+        responseStr);
+  } catch (kj::Exception &e) {
+    KJ_LOG(ERROR, "Error building error response string", e.getDescription());
     return CAPNP_LS_NONE;
   }
 }

--- a/src/lsp_message_handler.h
+++ b/src/lsp_message_handler.h
@@ -46,6 +46,8 @@ public:
 private:
   kj::Maybe<kj::String>
   buildResponseString(const double id, const capnp::JsonValue::Reader &result);
+  kj::Maybe<kj::String>
+  buildErrorResponseString(const double id, int code, kj::StringPtr message);
   kj::Promise<void> handleShutdown();
   kj::Promise<void> handleDefinition(
       const capnp::JsonValue::Reader &params,

--- a/src/lsp_types.h
+++ b/src/lsp_types.h
@@ -26,6 +26,7 @@ constexpr const char LSP_PARAMS[] = "params";
 constexpr const char LSP_ID[] = "id";
 constexpr const char LSP_JSONRPC[] = "jsonrpc";
 constexpr const char LSP_RESULT[] = "result";
+constexpr const char LSP_ERROR[] = "error";
 
 #define LSP_FOR_EACH_METHOD(MACRO)                                             \
   MACRO(INITIALIZE, "initialize")                                              \

--- a/tests/initialize_config_test.cpp
+++ b/tests/initialize_config_test.cpp
@@ -12,6 +12,7 @@
 #include <fstream>
 #include <kj/async-io.h>
 #include <kj/debug.h>
+#include <string>
 #include <unistd.h>
 
 namespace {
@@ -38,6 +39,35 @@ public:
   }
 };
 
+class CapturingOutputStream final : public kj::AsyncOutputStream {
+public:
+#if CAPNP_VERSION_MAJOR >= 2
+  kj::Promise<void> write(kj::ArrayPtr<const kj::byte> buffer) override {
+    output.append(reinterpret_cast<const char *>(buffer.begin()), buffer.size());
+    return kj::READY_NOW;
+  }
+#else
+  kj::Promise<void> write(const void *buffer, size_t size) override {
+    output.append(reinterpret_cast<const char *>(buffer), size);
+    return kj::READY_NOW;
+  }
+#endif
+
+  kj::Promise<void>
+  write(kj::ArrayPtr<const kj::ArrayPtr<const kj::byte>> pieces) override {
+    for (auto piece : pieces) {
+      output.append(reinterpret_cast<const char *>(piece.begin()), piece.size());
+    }
+    return kj::READY_NOW;
+  }
+
+  kj::Promise<void> whenWriteDisconnected() override {
+    return kj::NEVER_DONE;
+  }
+
+  std::string output;
+};
+
 void require(bool condition, kj::StringPtr message) {
   if (!condition) {
     KJ_FAIL_REQUIRE(message);
@@ -61,6 +91,16 @@ void decodeJson(kj::StringPtr json, capnp::MallocMessageBuilder &builder) {
   capnp::JsonCodec codec;
   auto root = builder.initRoot<capnp::JsonValue>();
   codec.decodeRaw(kj::arrayPtr(json.begin(), json.size()), root);
+}
+
+kj::StringPtr responseJson(kj::StringPtr message) {
+  kj::StringPtr delimiter = "\r\n\r\n";
+  for (auto i = 0; i + delimiter.size() <= message.size(); ++i) {
+    if (message.slice(i, i + delimiter.size()) == delimiter) {
+      return message.slice(i + delimiter.size());
+    }
+  }
+  KJ_FAIL_REQUIRE("response should include an LSP header");
 }
 
 bool hasObjectField(
@@ -186,6 +226,37 @@ int main() {
     require(
         handler.testImportPath(0) == "override",
         "initialization option import path should be preserved");
+  }
+
+  {
+    auto stream = kj::heap<CapturingOutputStream>();
+    auto &captured = *stream;
+    capnp_ls::StdoutWriter writer(kj::mv(stream));
+    capnp_ls::LspMessageHandler handler(context, writer);
+    handler
+        .handleMessage(kj::str(
+            "Content-Length: 67\r\n\r\n",
+            R"({"jsonrpc":"2.0","id":42,"method":"textDocument/completion"})"))
+        .wait(io.waitScope);
+
+    capnp::MallocMessageBuilder response;
+    decodeJson(
+        responseJson(
+            kj::StringPtr(captured.output.data(), captured.output.size())),
+        response);
+    auto responseRoot = response.getRoot<capnp::JsonValue>().asReader();
+    auto error = getObjectField(responseRoot, "error");
+    auto code = getObjectField(error, "code");
+    auto message = getObjectField(error, "message");
+    require(
+        code.getNumber() == -32601,
+        "unknown request should return Method not found");
+    require(
+        message.getString() == "Method not found",
+        "unknown request should include a Method not found message");
+    require(
+        !hasObjectField(responseRoot, "result"),
+        "unknown request response should not include result");
   }
 
   return 0;


### PR DESCRIPTION
## Summary
- return JSON-RPC Method not found errors for unsupported LSP requests instead of leaving request handling on the normal result path
- downgrade unsupported-method logging from error to info
- add a regression test for textDocument/completion requests, which are not advertised by the server

## Verification
- just test
- pnpm --dir samples test