### PR TITLE
Bump VS Code client server default to v0.0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Cap'n Proto channel with environment variables:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/trickstar0301/capnp-ls/main/install.sh \
-  | CAPNP_LS_VERSION=v0.0.3 \
+  | CAPNP_LS_VERSION=v0.0.4 \
     CAPNP_LS_INSTALL_DIR="$HOME/.local/bin" \
     CAPNP_LS_CAPNP_VERSION=v2 \
     sh
@@ -106,7 +106,7 @@ To build a macOS arm64 release artifact locally:
 ```bash
 scripts/build-macos-arm64-release.sh v1 /path/to/capnproto-v1.4.0/c++
 gh release upload \
-  v0.0.3 \
+  v0.0.4 \
   dist/capnp-ls-macos-arm64-capnp-v1 \
   dist/capnp-ls-macos-arm64-capnp-v1.sha256 \
   --clobber

--- a/samples/package.json
+++ b/samples/package.json
@@ -3,7 +3,7 @@
 	"description": "A language client of Cap'n Proto Language Server",
 	"author": "Atsushi Tomida",
 	"license": "MIT",
-	"version": "0.3.0",
+	"version": "0.3.1",
 	"packageManager": "pnpm@11.5.2",
 	"repository": {
 		"type": "git",
@@ -38,7 +38,7 @@
 				},
 				"capnp-ls-client.languageServer.version": {
 					"type": "string",
-					"default": "v0.0.3",
+					"default": "v0.0.4",
 					"description": "capnp-ls release tag used for automatic Linux x86_64 and macOS arm64 downloads"
 				},
 				"capnp-ls-client.languageServer.capnpChannel": {


### PR DESCRIPTION
## Summary
- bump the VS Code extension version to 0.3.1
- point the default bundled server release setting at capnp-ls v0.0.4
- update README examples to use v0.0.4

## Verification
- pnpm --dir samples test
- git diff --check