### PR TITLE
Fix VS Code client binary permissions

### DIFF
--- a/samples/client/src/extension.ts
+++ b/samples/client/src/extension.ts
@@ -140,7 +140,14 @@ export async function activate(context: ExtensionContext) {
 				log(`Found language server at: ${extensionVersionedBinaryPath}`);
 				return extensionVersionedBinaryPath;
 			} catch (e) {
-				throw new Error(`Language server is not executable: ${extensionVersionedBinaryPath}`);
+				try {
+					await fs.promises.chmod(extensionVersionedBinaryPath, 0o755);
+					fs.accessSync(extensionVersionedBinaryPath, fs.constants.X_OK);
+					log(`Fixed language server executable permission at: ${extensionVersionedBinaryPath}`);
+					return extensionVersionedBinaryPath;
+				} catch {
+					throw new Error(`Language server is not executable: ${extensionVersionedBinaryPath}`);
+				}
 			}
 		}
 

--- a/samples/package.json
+++ b/samples/package.json
@@ -3,7 +3,7 @@
 	"description": "A language client of Cap'n Proto Language Server",
 	"author": "Atsushi Tomida",
 	"license": "MIT",
-	"version": "0.3.1",
+	"version": "0.3.2",
 	"packageManager": "pnpm@11.5.2",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
## Summary
- make the VS Code client repair executable permissions on the bundled language server binary before failing
- bump the sample extension package version to 0.3.2

## Testing
- Not run; PR creation only requested.