### PR TITLE
Default VS Code server logs to warning

### DIFF
--- a/samples/client/src/extension.ts
+++ b/samples/client/src/extension.ts
@@ -18,6 +18,20 @@ import {
 let client: LanguageClient;
 
 type ReleasePlatform = 'linux-x86_64' | 'macos-arm64';
+type ServerExtraEnv = Record<string, string | number>;
+
+export function createServerEnvironment(
+	baseEnv: NodeJS.ProcessEnv,
+	extraEnv: ServerExtraEnv
+): NodeJS.ProcessEnv {
+	return {
+		...baseEnv,
+		CPP_LOG: 'lsp_server=warning',
+		...Object.fromEntries(
+			Object.entries(extraEnv).map(([key, value]) => [key, String(value)])
+		)
+	};
+}
 
 export async function activate(context: ExtensionContext) {
 	if (process.platform === 'win32') {
@@ -58,7 +72,7 @@ export async function activate(context: ExtensionContext) {
 	// Get configuration
 	const config = workspace.getConfiguration('capnp-ls-client');
 	const serverPathRaw = config.get<string>('languageServer.path');
-	const extraEnv = config.get<Record<string, string | number>>('server.extraEnv') || {};
+	const extraEnv = config.get<ServerExtraEnv>('server.extraEnv') || {};
 	const serverVersion = config.get<string>('languageServer.version');
 	const capnpChannel = config.get<string>('languageServer.capnpChannel');
 	if (!serverVersion || !capnpChannel) {
@@ -252,10 +266,7 @@ export async function activate(context: ExtensionContext) {
 		args: [],
 		options: {
 			cwd: path.dirname(resolvedServerPath),
-			env: {
-				...process.env,
-				...extraEnv
-			}
+			env: createServerEnvironment(process.env, extraEnv)
 		}
 	};
 

--- a/samples/client/src/test/serverEnvironment.test.ts
+++ b/samples/client/src/test/serverEnvironment.test.ts
@@ -1,0 +1,28 @@
+// Copyright (c) 2024 Atsushi Tomida
+//
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
+
+import * as assert from 'assert';
+import { createServerEnvironment } from '../extension';
+
+suite('Server Environment', () => {
+	test('defaults CPP_LOG to warning instead of inheriting parent CPP_LOG', () => {
+		const env = createServerEnvironment(
+			{ CPP_LOG: 'lsp_server=info', PATH: '/bin' },
+			{}
+		);
+
+		assert.strictEqual(env.CPP_LOG, 'lsp_server=warning');
+		assert.strictEqual(env.PATH, '/bin');
+	});
+
+	test('allows extraEnv to override default CPP_LOG', () => {
+		const env = createServerEnvironment(
+			{ CPP_LOG: 'lsp_server=warning' },
+			{ CPP_LOG: 'lsp_server=info' }
+		);
+
+		assert.strictEqual(env.CPP_LOG, 'lsp_server=info');
+	});
+});


### PR DESCRIPTION
## Summary
- default the VS Code client's server CPP_LOG to lsp_server=warning
- keep capnp-ls-client.server.extraEnv able to override CPP_LOG for debugging
- add tests for default and override behavior

## Tests
- pnpm --dir samples compile
- pnpm --dir samples test
- just test