### PR TITLE
Support workspace log level config

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,22 @@ Supported Cap'n Proto source channels:
 
 The executable for the language server is located at `build/capnp-ls`.
 
+## Workspace Configuration
+
+The language server reads `.capnp-ls.json` from the workspace root. Use
+`importPaths` for project-specific schema import directories and `logLevel` to
+set workspace logging. Supported log levels are `error`, `warning`, and `info`;
+the default is `warning`.
+
+```json
+{
+  "logLevel": "warning",
+  "importPaths": [
+    "path/to/schema/imports"
+  ]
+}
+```
+
 ## Release Artifacts
 
 Release artifacts are versioned by the Cap'n Proto compatibility channel. Each

--- a/samples/README.md
+++ b/samples/README.md
@@ -23,9 +23,6 @@ This extension contributes the following settings:
 * `capnp-ls-client.languageServer.capnpChannel`: Cap'n Proto compatibility channel for the automatically downloaded language server binary. Supported values are `v1` and `v2`.
   * Changing the server path, release version, or Cap'n Proto channel prompts you to reload VS Code so the new server binary is used.
 * `capnp-ls-client.server.extraEnv`: Extra environment variables that will be passed to the capnp-ls executable.
-  * `CPP_LOG`: Process-wide fallback log level for the Cap'n Proto language server. Prefer `.capnp-ls.json` for workspace-specific log level changes.
-    * Example: `CPP_LOG=lsp_server=info`: Set the fallback log level to info.
-    * Default: `CPP_LOG=lsp_server=warning`
 
 #### Example configuration:
 

--- a/samples/README.md
+++ b/samples/README.md
@@ -23,17 +23,19 @@ This extension contributes the following settings:
 * `capnp-ls-client.languageServer.capnpChannel`: Cap'n Proto compatibility channel for the automatically downloaded language server binary. Supported values are `v1` and `v2`.
   * Changing the server path, release version, or Cap'n Proto channel prompts you to reload VS Code so the new server binary is used.
 * `capnp-ls-client.server.extraEnv`: Extra environment variables that will be passed to the capnp-ls executable.
-  * `CPP_LOG`: Log level for the Cap'n Proto language server.
-    * Example: `CPP_LOG=lsp_server=info`: Set log level to info.
+  * `CPP_LOG`: Process-wide fallback log level for the Cap'n Proto language server. Prefer `.capnp-ls.json` for workspace-specific log level changes.
+    * Example: `CPP_LOG=lsp_server=info`: Set the fallback log level to info.
     * Default: `CPP_LOG=lsp_server=warning`
 
 #### Example configuration:
 
 Project-specific import paths are read by the language server from
-`.capnp-ls.json` in your workspace root:
+`.capnp-ls.json` in your workspace root. The same file can set the workspace
+log level to `error`, `warning`, or `info`:
 
 ```json
 {
+    "logLevel": "warning",
     "importPaths": [
         "path/to/schema/imports"
     ]
@@ -45,10 +47,7 @@ To customize client settings, configure them in VS Code User Settings:
 ```json
 {
     "capnp-ls-client.languageServer.path": "/absolute/path/to/capnp-ls",
-    "capnp-ls-client.languageServer.capnpChannel": "v1",
-    "capnp-ls-client.server.extraEnv": {
-        "CPP_LOG": "lsp_server=warning"
-    }
+    "capnp-ls-client.languageServer.capnpChannel": "v1"
 }
 ```
 ## Release Artifact Availability

--- a/samples/client/src/extension.ts
+++ b/samples/client/src/extension.ts
@@ -26,7 +26,6 @@ export function createServerEnvironment(
 ): NodeJS.ProcessEnv {
 	return {
 		...baseEnv,
-		CPP_LOG: 'lsp_server=warning',
 		...Object.fromEntries(
 			Object.entries(extraEnv).map(([key, value]) => [key, String(value)])
 		)

--- a/samples/client/src/test/runTest.ts
+++ b/samples/client/src/test/runTest.ts
@@ -26,10 +26,7 @@ async function main() {
 		await fs.mkdir(userSettingsDir, { recursive: true });
 		await fs.writeFile(path.join(userSettingsDir, 'settings.json'), JSON.stringify({
 			'capnp-ls-client.languageServer.path': path.resolve(extensionDevelopmentPath, '../build/capnp-ls'),
-			'capnp-ls-client.languageServer.capnpChannel': 'v1',
-			'capnp-ls-client.server.extraEnv': {
-				CPP_LOG: 'lsp_server=info'
-			}
+			'capnp-ls-client.languageServer.capnpChannel': 'v1'
 		}, null, 2));
 
 		// Download VS Code, unzip it and run the integration test

--- a/samples/client/src/test/serverEnvironment.test.ts
+++ b/samples/client/src/test/serverEnvironment.test.ts
@@ -7,22 +7,22 @@ import * as assert from 'assert';
 import { createServerEnvironment } from '../extension';
 
 suite('Server Environment', () => {
-	test('defaults CPP_LOG to warning instead of inheriting parent CPP_LOG', () => {
+	test('preserves the parent environment without adding CPP_LOG', () => {
 		const env = createServerEnvironment(
-			{ CPP_LOG: 'lsp_server=info', PATH: '/bin' },
+			{ PATH: '/bin' },
 			{}
 		);
 
-		assert.strictEqual(env.CPP_LOG, 'lsp_server=warning');
+		assert.strictEqual(env.CPP_LOG, undefined);
 		assert.strictEqual(env.PATH, '/bin');
 	});
 
-	test('allows extraEnv to override default CPP_LOG', () => {
+	test('allows extraEnv to add stringified values', () => {
 		const env = createServerEnvironment(
-			{ CPP_LOG: 'lsp_server=warning' },
-			{ CPP_LOG: 'lsp_server=info' }
+			{ PATH: '/bin' },
+			{ CAPNP_LS_TEST_VALUE: 123 }
 		);
 
-		assert.strictEqual(env.CPP_LOG, 'lsp_server=info');
+		assert.strictEqual(env.CAPNP_LS_TEST_VALUE, '123');
 	});
 });

--- a/samples/client/testFixture/schemas/syntax.capnp
+++ b/samples/client/testFixture/schemas/syntax.capnp
@@ -16,7 +16,7 @@ enum Role {
 
 struct Person {
   id @0: UInt64;
-  name @1: Text = defaultName;
+  name @1: Text = .defaultName;
   role @2: Role;
   tags @3: List(Text);
   oldName @4: Text $deprecated("Use name instead");

--- a/samples/package.json
+++ b/samples/package.json
@@ -62,7 +62,7 @@
 						]
 					},
 					"default": null,
-					"markdownDescription": "Extra environment variables that will be passed to the capnp-ls executable. Prefer `.capnp-ls.json` `logLevel` for workspace-specific logging; `CPP_LOG=lsp_server=info` can still set a process-wide fallback for debugging."
+					"markdownDescription": "Extra environment variables that will be passed to the capnp-ls executable."
 				}
 			}
 		},

--- a/samples/package.json
+++ b/samples/package.json
@@ -62,7 +62,7 @@
 						]
 					},
 					"default": null,
-					"markdownDescription": "Extra environment variables that will be passed to the capnp-ls executable. Useful for passing e.g. `CPP_LOG=lsp_server=info` for debugging."
+					"markdownDescription": "Extra environment variables that will be passed to the capnp-ls executable. Prefer `.capnp-ls.json` `logLevel` for workspace-specific logging; `CPP_LOG=lsp_server=info` can still set a process-wide fallback for debugging."
 				}
 			}
 		},

--- a/src/log_level.h
+++ b/src/log_level.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include "kj_compat.h"
 #include <kj/debug.h>
 #include <kj/string.h>
 
@@ -23,7 +24,7 @@ inline kj::Maybe<LogLevel> parseLogLevel(kj::StringPtr level) {
     return LogLevel::INFO;
   }
 
-  return kj::none;
+  return CAPNP_LS_NONE;
 }
 
 inline kj::LogSeverity toKjLogSeverity(LogLevel level) {

--- a/src/log_level.h
+++ b/src/log_level.h
@@ -1,0 +1,65 @@
+// Copyright (c) 2024 Atsushi Tomida
+//
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
+
+#pragma once
+
+#include <cstdlib>
+#include <kj/debug.h>
+#include <kj/string.h>
+
+namespace capnp_ls {
+
+enum class LogLevel { ERROR, WARNING, INFO };
+
+inline kj::Maybe<LogLevel> parseLogLevel(kj::StringPtr level) {
+  if (level == "error") {
+    return LogLevel::ERROR;
+  }
+  if (level == "warning") {
+    return LogLevel::WARNING;
+  }
+  if (level == "info") {
+    return LogLevel::INFO;
+  }
+
+  return kj::none;
+}
+
+inline kj::LogSeverity toKjLogSeverity(LogLevel level) {
+  switch (level) {
+  case LogLevel::ERROR:
+    return kj::LogSeverity::ERROR;
+  case LogLevel::WARNING:
+    return kj::LogSeverity::WARNING;
+  case LogLevel::INFO:
+    return kj::LogSeverity::INFO;
+  }
+
+  KJ_UNREACHABLE;
+}
+
+inline void applyLogLevel(LogLevel level) {
+  kj::_::Debug::setLogLevel(toKjLogSeverity(level));
+}
+
+inline LogLevel logLevelFromEnvironment() {
+  const char *logEnv = std::getenv("CPP_LOG");
+  if (logEnv == nullptr) {
+    return LogLevel::WARNING;
+  }
+
+  kj::StringPtr logStr(logEnv);
+  if (!logStr.startsWith("lsp_server=")) {
+    return LogLevel::WARNING;
+  }
+
+  KJ_IF_SOME(level, parseLogLevel(logStr.slice(11))) {
+    return level;
+  }
+
+  return LogLevel::WARNING;
+}
+
+} // namespace capnp_ls

--- a/src/log_level.h
+++ b/src/log_level.h
@@ -5,7 +5,6 @@
 
 #pragma once
 
-#include <cstdlib>
 #include <kj/debug.h>
 #include <kj/string.h>
 
@@ -42,24 +41,6 @@ inline kj::LogSeverity toKjLogSeverity(LogLevel level) {
 
 inline void applyLogLevel(LogLevel level) {
   kj::_::Debug::setLogLevel(toKjLogSeverity(level));
-}
-
-inline LogLevel logLevelFromEnvironment() {
-  const char *logEnv = std::getenv("CPP_LOG");
-  if (logEnv == nullptr) {
-    return LogLevel::WARNING;
-  }
-
-  kj::StringPtr logStr(logEnv);
-  if (!logStr.startsWith("lsp_server=")) {
-    return LogLevel::WARNING;
-  }
-
-  KJ_IF_SOME(level, parseLogLevel(logStr.slice(11))) {
-    return level;
-  }
-
-  return LogLevel::WARNING;
 }
 
 } // namespace capnp_ls

--- a/src/logger.h
+++ b/src/logger.h
@@ -5,58 +5,23 @@
 
 #pragma once
 
+#include "log_level.h"
 #include "stdout_writer.h"
 #include <capnp/compat/json.h>
 #include <capnp/message.h>
-#include <cstdlib>
 #include <kj/debug.h>
 #include <kj/exception.h>
 
 namespace capnp_ls {
 
-enum class LogLevel { ERROR, WARNING, INFO };
-
 class LspLogger : public kj::ExceptionCallback {
 public:
   LspLogger(StdoutWriter &writer) : writer(writer) {
-    // Get log level from environment variable
-    const char *logEnv = std::getenv("CPP_LOG");
-    LogLevel level = LogLevel::WARNING; // Default log level
-
-    if (logEnv != nullptr) {
-      kj::StringPtr logStr(logEnv);
-
-      // Parse environment variable format: lsp_server=level
-      if (logStr.startsWith("lsp_server=")) {
-        auto levelStr = logStr.slice(11); // Skip "lsp_server="
-
-        if (levelStr == "error") {
-          level = LogLevel::ERROR;
-        } else if (levelStr == "warning") {
-          level = LogLevel::WARNING;
-        } else if (levelStr == "info") {
-          level = LogLevel::INFO;
-        }
-      }
-    }
-
-    // Set KJ log level
-    kj::LogSeverity kjLogLevel;
-    switch (level) {
-    case LogLevel::ERROR:
-      kjLogLevel = kj::LogSeverity::ERROR;
-      break;
-    case LogLevel::WARNING:
-      kjLogLevel = kj::LogSeverity::WARNING;
-      break;
-    case LogLevel::INFO:
-      kjLogLevel = kj::LogSeverity::INFO;
-      break;
-    }
-    kj::_::Debug::setLogLevel(kjLogLevel);
+    auto level = logLevelFromEnvironment();
+    applyLogLevel(level);
 
     // Log the current log level
-    KJ_LOG(INFO, "Log level set to", kjLogLevel);
+    KJ_LOG(INFO, "Log level set to", toKjLogSeverity(level));
   }
 
   void logMessage(

--- a/src/logger.h
+++ b/src/logger.h
@@ -17,7 +17,7 @@ namespace capnp_ls {
 class LspLogger : public kj::ExceptionCallback {
 public:
   LspLogger(StdoutWriter &writer) : writer(writer) {
-    auto level = logLevelFromEnvironment();
+    auto level = LogLevel::WARNING;
     applyLogLevel(level);
 
     // Log the current log level

--- a/src/lsp_message_handler.cpp
+++ b/src/lsp_message_handler.cpp
@@ -87,13 +87,15 @@ LspMessageHandler::handleMessage(kj::Maybe<kj::String> maybeMessage) {
         case LspMethod::DID_SAVE:
           promise = handleDidSave(params);
           break;
+        case LspMethod::DID_CHANGE_WATCHED_FILES:
+          promise = handleDidChangeWatchedFiles(params);
+          break;
         case LspMethod::FORMATTING:
           promise = handleFormatting(params, *responseMessageBuilder);
           break;
         case LspMethod::INITIALIZED:
         case LspMethod::SET_TRACE:
         case LspMethod::CANCEL_REQUEST:
-        case LspMethod::DID_CHANGE_WATCHED_FILES:
         case LspMethod::DID_CHANGE:
         case LspMethod::DID_CLOSE:
           // KJ_LOG(INFO, "Ignoring method", method.cStr());

--- a/src/lsp_message_handler.cpp
+++ b/src/lsp_message_handler.cpp
@@ -157,8 +157,8 @@ bool LspMessageHandler::reloadProjectConfig() {
 
   ProjectConfig loadedConfig;
   if (loadProjectConfig(workspacePath, loadedConfig)) {
-    KJ_IF_SOME(logLevel, loadedConfig.logLevel) {
-      currentLogLevel = logLevel;
+    CAPNP_LS_IF_SOME (logLevel, loadedConfig.logLevel) {
+      currentLogLevel = *logLevel;
     } else {
       currentLogLevel = defaultLogLevel;
     }
@@ -317,7 +317,8 @@ LspMessageHandler::publishDiagnostics(
 
   for (auto &previousFile : previousDiagnosticFiles) {
     bool stillHasDiagnostics = false;
-    CAPNP_LS_IF_SOME (_, diagnosticMap.find(previousFile)) {
+    CAPNP_LS_IF_SOME (diagnostics, diagnosticMap.find(previousFile)) {
+      (void)diagnostics;
       stillHasDiagnostics = true;
     }
     if (previousFile != fileName && !stillHasDiagnostics) {

--- a/src/lsp_message_handler.cpp
+++ b/src/lsp_message_handler.cpp
@@ -148,30 +148,42 @@ bool LspMessageHandler::isProjectConfigPath(kj::StringPtr path) {
 }
 
 bool LspMessageHandler::reloadProjectConfig() {
-  if (importPathsConfiguredByInitialization) {
-    KJ_LOG(INFO, "Skipping project config reload because initialization options configured import paths");
-    return false;
-  }
   if (workspacePath.size() == 0) {
     KJ_LOG(INFO, "Skipping project config reload because workspace path is not set");
     return false;
   }
 
-  kj::Vector<kj::String> loadedImportPaths;
-  if (loadProjectConfigImportPaths(workspacePath, loadedImportPaths)) {
-    importPaths.clear();
-    for (auto &path : loadedImportPaths) {
-      importPaths.add(kj::mv(path));
+  ProjectConfig loadedConfig;
+  if (loadProjectConfig(workspacePath, loadedConfig)) {
+    KJ_IF_SOME(logLevel, loadedConfig.logLevel) {
+      currentLogLevel = logLevel;
+    } else {
+      currentLogLevel = defaultLogLevel;
     }
+    applyLogLevel(currentLogLevel);
+
+    if (!importPathsConfiguredByInitialization) {
+      importPaths.clear();
+      for (auto &path : loadedConfig.importPaths) {
+        importPaths.add(kj::mv(path));
+      }
+    } else {
+      KJ_LOG(INFO, "Skipping project config import paths because initialization options configured import paths");
+    }
+
     clearCompilationState();
     KJ_LOG(INFO, "Project config reloaded");
     return true;
   }
 
   if (!projectConfigExists(workspacePath)) {
-    importPaths.clear();
+    currentLogLevel = defaultLogLevel;
+    applyLogLevel(currentLogLevel);
+    if (!importPathsConfiguredByInitialization) {
+      importPaths.clear();
+    }
     clearCompilationState();
-    KJ_LOG(INFO, "Project config removed; import paths cleared");
+    KJ_LOG(INFO, "Project config removed; defaults restored");
     return true;
   }
 

--- a/src/lsp_message_handler.cpp
+++ b/src/lsp_message_handler.cpp
@@ -271,6 +271,11 @@ kj::Maybe<kj::String> LspMessageHandler::buildErrorResponseString(
 kj::Promise<void> LspMessageHandler::compileCapnpFile(kj::StringPtr uri) {
   auto strippedUri = uriToPath(uri);
   if (strippedUri.endsWith(".capnp")) {
+    kj::Vector<kj::String> previousDiagnosticFiles;
+    for (const auto &[diagnosticUri, _] : diagnosticMap) {
+      previousDiagnosticFiles.add(kj::heapString(diagnosticUri));
+    }
+
     return compilationManager
         ->compile(CompilationManager::CompileParams(
             importPaths,
@@ -279,17 +284,51 @@ kj::Promise<void> LspMessageHandler::compileCapnpFile(kj::StringPtr uri) {
             fileSourceInfoMap,
             nodeLocationMap,
             diagnosticMap))
-        .then([this, strippedUri = kj::mv(strippedUri)]() {
-          return publishDiagnostics(strippedUri);
+        .then([this,
+               strippedUri = kj::mv(strippedUri),
+               previousDiagnosticFiles = kj::mv(previousDiagnosticFiles)]() mutable {
+          return publishDiagnostics(
+              strippedUri,
+              kj::mv(previousDiagnosticFiles));
         });
   }
   return kj::READY_NOW;
 }
 
 kj::Promise<void>
-LspMessageHandler::publishDiagnostics(kj::StringPtr fileName) {
+LspMessageHandler::publishDiagnostics(
+    kj::StringPtr fileName,
+    kj::Vector<kj::String> previousDiagnosticFiles) {
   KJ_LOG(INFO, "Publishing diagnostics");
 
+  bool publishedCurrentFile = false;
+  for (const auto &[uri, diagnostics] : diagnosticMap) {
+    if (uri == fileName) {
+      publishedCurrentFile = true;
+    }
+    (void)publishDiagnosticsForFile(uri, &diagnostics);
+  }
+
+  if (!publishedCurrentFile) {
+    (void)publishDiagnosticsForFile(fileName, nullptr);
+  }
+
+  for (auto &previousFile : previousDiagnosticFiles) {
+    bool stillHasDiagnostics = false;
+    CAPNP_LS_IF_SOME (_, diagnosticMap.find(previousFile)) {
+      stillHasDiagnostics = true;
+    }
+    if (previousFile != fileName && !stillHasDiagnostics) {
+      (void)publishDiagnosticsForFile(previousFile, nullptr);
+    }
+  }
+
+  return kj::READY_NOW;
+}
+
+kj::Promise<void> LspMessageHandler::publishDiagnosticsForFile(
+    kj::StringPtr fileName,
+    const kj::Vector<Diagnostic> *diagnostics) {
   try {
     capnp::MallocMessageBuilder messageBuilder;
     auto root = messageBuilder.initRoot<capnp::JsonValue>();
@@ -307,97 +346,68 @@ LspMessageHandler::publishDiagnostics(kj::StringPtr fileName) {
     notificationObj[2].setName(LSP_PARAMS);
     auto params = notificationObj[2].getValue().initObject(2);
 
-    if (diagnosticMap.size() == 0) {
-      // If there are no diagnostics, send an empty diagnostics array for the
-      // current file
-      params[0].setName("uri");
-      // Ensure fileName is relative to workspacePath
-      kj::StringPtr relativeFileName = fileName;
-      if (fileName.startsWith(workspacePath)) {
-        relativeFileName = fileName.slice(
-            workspacePath.size() + 1); // +1 for the trailing slash
-      }
-      kj::String fullUri =
-          kj::str("file://", workspacePath, "/", relativeFileName);
-      params[0].getValue().setString(fullUri);
-
-      params[1].setName("diagnostics");
-      params[1].getValue().initArray(0);
-
-      capnp::JsonCodec codec;
-      kj::String notificationStr = codec.encodeRaw(root);
-      kj::String message = kj::str(
-          LSP_CONTENT_LENGTH_HEADER,
-          notificationStr.size(),
-          LSP_HEADER_DELIMITER,
-          notificationStr);
-      (void)stdoutWriter.write(message);
-    } else {
-      for (const auto &[uri, diagnostics] : diagnosticMap) {
-        // Set URI
-        params[0].setName("uri");
-        // Ensure uri is relative to workspacePath
-        kj::StringPtr relativeUri = uri;
-        if (uri.startsWith(workspacePath)) {
-          relativeUri =
-              uri.slice(workspacePath.size() + 1); // +1 for the trailing slash
-        }
-        kj::String fullUri =
-            kj::str("file://", workspacePath, "/", relativeUri);
-        params[0].getValue().setString(fullUri);
-
-        // Set diagnostics array
-        params[1].setName("diagnostics");
-        auto diagnosticsArray =
-            params[1].getValue().initArray(diagnostics.size());
-
-        for (size_t i = 0; i < diagnostics.size(); i++) {
-          const auto &diagnostic = diagnostics[i];
-          auto diagnosticObj = diagnosticsArray[i].initObject(3);
-
-          // Set severity
-          diagnosticObj[0].setName("severity");
-          diagnosticObj[0].getValue().setNumber(1); // Error = 1
-
-          // Set message
-          diagnosticObj[1].setName("message");
-          diagnosticObj[1].getValue().setString(diagnostic.message);
-
-          // Set range
-          diagnosticObj[2].setName("range");
-          auto rangeObj = diagnosticObj[2].getValue().initObject(2);
-
-          // Start position
-          auto startObj = rangeObj[0];
-          startObj.setName("start");
-          auto start = startObj.getValue().initObject(2);
-          start[0].setName("line");
-          start[0].getValue().setNumber(diagnostic.range.start.line);
-          start[1].setName("character");
-          start[1].getValue().setNumber(diagnostic.range.start.character);
-
-          // End position
-          auto endObj = rangeObj[1];
-          endObj.setName("end");
-          auto end = endObj.getValue().initObject(2);
-          end[0].setName("line");
-          end[0].getValue().setNumber(diagnostic.range.end.line);
-          end[1].setName("character");
-          end[1].getValue().setNumber(diagnostic.range.end.character);
-        }
-
-        // Encode and send the notification
-        capnp::JsonCodec codec;
-        kj::String notificationStr = codec.encodeRaw(root);
-        kj::String message = kj::str(
-            LSP_CONTENT_LENGTH_HEADER,
-            notificationStr.size(),
-            LSP_HEADER_DELIMITER,
-            notificationStr);
-
-        (void)stdoutWriter.write(message);
-      }
+    // Set URI
+    params[0].setName("uri");
+    // Ensure fileName is relative to workspacePath
+    kj::StringPtr relativeFileName = fileName;
+    if (fileName.startsWith(workspacePath)) {
+      relativeFileName = fileName.slice(
+          workspacePath.size() + 1); // +1 for the trailing slash
     }
+    kj::String fullUri =
+        kj::str("file://", workspacePath, "/", relativeFileName);
+    params[0].getValue().setString(fullUri);
+
+    // Set diagnostics array
+    params[1].setName("diagnostics");
+    auto diagnosticsSize = diagnostics == nullptr ? 0 : diagnostics->size();
+    auto diagnosticsArray = params[1].getValue().initArray(diagnosticsSize);
+
+    for (size_t i = 0; i < diagnosticsSize; i++) {
+      const auto &diagnostic = (*diagnostics)[i];
+      auto diagnosticObj = diagnosticsArray[i].initObject(3);
+
+      // Set severity
+      diagnosticObj[0].setName("severity");
+      diagnosticObj[0].getValue().setNumber(1); // Error = 1
+
+      // Set message
+      diagnosticObj[1].setName("message");
+      diagnosticObj[1].getValue().setString(diagnostic.message);
+
+      // Set range
+      diagnosticObj[2].setName("range");
+      auto rangeObj = diagnosticObj[2].getValue().initObject(2);
+
+      // Start position
+      auto startObj = rangeObj[0];
+      startObj.setName("start");
+      auto start = startObj.getValue().initObject(2);
+      start[0].setName("line");
+      start[0].getValue().setNumber(diagnostic.range.start.line);
+      start[1].setName("character");
+      start[1].getValue().setNumber(diagnostic.range.start.character);
+
+      // End position
+      auto endObj = rangeObj[1];
+      endObj.setName("end");
+      auto end = endObj.getValue().initObject(2);
+      end[0].setName("line");
+      end[0].getValue().setNumber(diagnostic.range.end.line);
+      end[1].setName("character");
+      end[1].getValue().setNumber(diagnostic.range.end.character);
+    }
+
+    // Encode and send the notification
+    capnp::JsonCodec codec;
+    kj::String notificationStr = codec.encodeRaw(root);
+    kj::String message = kj::str(
+        LSP_CONTENT_LENGTH_HEADER,
+        notificationStr.size(),
+        LSP_HEADER_DELIMITER,
+        notificationStr);
+
+    (void)stdoutWriter.write(message);
   } catch (kj::Exception &e) {
     KJ_LOG(ERROR, "Error publishing diagnostics", e.getDescription());
   }

--- a/src/lsp_message_handler.h
+++ b/src/lsp_message_handler.h
@@ -67,7 +67,12 @@ private:
   kj::Promise<void> handleFormatting(
       const capnp::JsonValue::Reader &params,
       capnp::MallocMessageBuilder &formattingResponseBuilder);
-  kj::Promise<void> publishDiagnostics(kj::StringPtr fileName);
+  kj::Promise<void> publishDiagnostics(
+      kj::StringPtr fileName,
+      kj::Vector<kj::String> previousDiagnosticFiles);
+  kj::Promise<void> publishDiagnosticsForFile(
+      kj::StringPtr fileName,
+      const kj::Vector<Diagnostic> *diagnostics);
   bool reloadProjectConfig();
   void clearCompilationState();
   bool isProjectConfigPath(kj::StringPtr path);

--- a/src/lsp_message_handler.h
+++ b/src/lsp_message_handler.h
@@ -78,7 +78,7 @@ private:
   kj::String workspacePath;
   kj::Vector<kj::String> importPaths;
   bool importPathsConfiguredByInitialization = false;
-  LogLevel defaultLogLevel = logLevelFromEnvironment();
+  LogLevel defaultLogLevel = LogLevel::WARNING;
   LogLevel currentLogLevel = defaultLogLevel;
   ServerContext &context;
   kj::Own<CompilationManager> compilationManager;

--- a/src/lsp_message_handler.h
+++ b/src/lsp_message_handler.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "compilation_manager.h"
+#include "log_level.h"
 #include "lsp_types.h"
 #include "server_context.h"
 #include "stdout_writer.h"
@@ -41,6 +42,9 @@ public:
   bool testReloadProjectConfig() {
     return reloadProjectConfig();
   }
+  LogLevel testLogLevel() const {
+    return currentLogLevel;
+  }
 #endif
 
 private:
@@ -74,6 +78,8 @@ private:
   kj::String workspacePath;
   kj::Vector<kj::String> importPaths;
   bool importPathsConfiguredByInitialization = false;
+  LogLevel defaultLogLevel = logLevelFromEnvironment();
+  LogLevel currentLogLevel = defaultLogLevel;
   ServerContext &context;
   kj::Own<CompilationManager> compilationManager;
   StdoutWriter &stdoutWriter;

--- a/src/project_config.cpp
+++ b/src/project_config.cpp
@@ -47,8 +47,8 @@ void parseProjectConfig(kj::StringPtr content, ProjectConfig &config) {
       }
     } else if (field.getName().asString() == kj::StringPtr("logLevel")) {
       KJ_REQUIRE(field.getValue().isString(), "logLevel must be a string");
-      KJ_IF_SOME(level, parseLogLevel(field.getValue().getString())) {
-        config.logLevel = level;
+      CAPNP_LS_IF_SOME (level, parseLogLevel(field.getValue().getString())) {
+        config.logLevel = *level;
       } else {
         KJ_FAIL_REQUIRE(
             "logLevel must be one of: error, warning, info",

--- a/src/project_config.cpp
+++ b/src/project_config.cpp
@@ -24,26 +24,41 @@ kj::String projectConfigPath(kj::StringPtr workspacePath) {
 void parseProjectConfigImportPaths(
     kj::StringPtr content,
     kj::Vector<kj::String> &importPaths) {
+  ProjectConfig config;
+  parseProjectConfig(content, config);
+  for (auto &path : config.importPaths) {
+    importPaths.add(kj::mv(path));
+  }
+}
+
+void parseProjectConfig(kj::StringPtr content, ProjectConfig &config) {
   capnp::JsonCodec codec;
   capnp::MallocMessageBuilder messageBuilder;
   auto root = messageBuilder.initRoot<capnp::JsonValue>();
   kj::ArrayPtr<const char> jsonContent(content.begin(), content.size());
   codec.decodeRaw(jsonContent, root);
 
-  auto config = root.getObject();
-  for (auto field : config) {
+  auto configObject = root.getObject();
+  for (auto field : configObject) {
     if (field.getName().asString() == kj::StringPtr("importPaths")) {
       auto paths = field.getValue().getArray();
       for (auto path : paths) {
-        importPaths.add(kj::heapString(kj::StringPtr(path.getString())));
+        config.importPaths.add(kj::heapString(kj::StringPtr(path.getString())));
+      }
+    } else if (field.getName().asString() == kj::StringPtr("logLevel")) {
+      KJ_REQUIRE(field.getValue().isString(), "logLevel must be a string");
+      KJ_IF_SOME(level, parseLogLevel(field.getValue().getString())) {
+        config.logLevel = level;
+      } else {
+        KJ_FAIL_REQUIRE(
+            "logLevel must be one of: error, warning, info",
+            field.getValue().getString());
       }
     }
   }
 }
 
-bool loadProjectConfigImportPaths(
-    kj::StringPtr workspacePath,
-    kj::Vector<kj::String> &importPaths) {
+bool loadProjectConfig(kj::StringPtr workspacePath, ProjectConfig &config) {
   auto configPath = projectConfigPath(workspacePath);
   std::ifstream input(configPath.cStr());
   if (!input.good()) {
@@ -56,13 +71,27 @@ bool loadProjectConfigImportPaths(
       std::istreambuf_iterator<char>());
 
   try {
-    parseProjectConfigImportPaths(kj::StringPtr(content.data(), content.size()), importPaths);
+    parseProjectConfig(kj::StringPtr(content.data(), content.size()), config);
   } catch (kj::Exception &e) {
     KJ_LOG(ERROR, "Failed to parse project config", configPath, e.getDescription());
     return false;
   }
 
   KJ_LOG(INFO, "Loaded project config", configPath);
+  return true;
+}
+
+bool loadProjectConfigImportPaths(
+    kj::StringPtr workspacePath,
+    kj::Vector<kj::String> &importPaths) {
+  ProjectConfig config;
+  if (!loadProjectConfig(workspacePath, config)) {
+    return false;
+  }
+
+  for (auto &path : config.importPaths) {
+    importPaths.add(kj::mv(path));
+  }
   return true;
 }
 

--- a/src/project_config.h
+++ b/src/project_config.h
@@ -5,12 +5,22 @@
 
 #pragma once
 
+#include "log_level.h"
 #include <kj/string.h>
 #include <kj/vector.h>
 
 namespace capnp_ls {
 
 constexpr const char *PROJECT_CONFIG_FILE = ".capnp-ls.json";
+
+struct ProjectConfig {
+  kj::Vector<kj::String> importPaths;
+  kj::Maybe<LogLevel> logLevel;
+};
+
+void parseProjectConfig(kj::StringPtr content, ProjectConfig &config);
+
+bool loadProjectConfig(kj::StringPtr workspacePath, ProjectConfig &config);
 
 void parseProjectConfigImportPaths(
     kj::StringPtr content,

--- a/tests/initialize_config_test.cpp
+++ b/tests/initialize_config_test.cpp
@@ -155,6 +155,9 @@ int main() {
         handler.testWorkspacePath() == CAPNP_LS_TEST_FIXTURE_DIR,
         "rootUri should be used when workspaceFolders is null");
     require(
+        handler.testLogLevel() == capnp_ls::LogLevel::WARNING,
+        "server log level should default to warning");
+    require(
         handler.testImportPathCount() == 2,
         "rootUri initialize should load .capnp-ls.json import paths");
 

--- a/tests/initialize_config_test.cpp
+++ b/tests/initialize_config_test.cpp
@@ -169,7 +169,7 @@ int main() {
   {
     auto workspace = makeTempWorkspace();
     KJ_DEFER(std::filesystem::remove_all(workspace));
-    writeConfig(workspace, R"({"importPaths":["one"]})");
+    writeConfig(workspace, R"({"importPaths":["one"],"logLevel":"info"})");
 
     capnp_ls::StdoutWriter writer(kj::heap<NullOutputStream>());
     capnp_ls::LspMessageHandler handler(context, writer);
@@ -187,24 +187,47 @@ int main() {
     require(
         handler.testImportPathCount() == 1 && handler.testImportPath(0) == "one",
         "initial import path should load from project config");
+    require(
+        handler.testLogLevel() == capnp_ls::LogLevel::INFO,
+        "initial log level should load from project config");
 
-    writeConfig(workspace, R"({"importPaths":["two","three"]})");
+    writeConfig(workspace, R"({"importPaths":["two","three"],"logLevel":"warning"})");
     require(handler.testReloadProjectConfig(), "valid config change should reload");
     require(
         handler.testImportPathCount() == 2 && handler.testImportPath(0) == "two",
         "changed project config should replace import paths");
+    require(
+        handler.testLogLevel() == capnp_ls::LogLevel::WARNING,
+        "changed project config should replace log level");
 
     writeConfig(workspace, R"({"importPaths":[)");
     require(!handler.testReloadProjectConfig(), "invalid config should not reload");
     require(
         handler.testImportPathCount() == 2 && handler.testImportPath(0) == "two",
         "invalid project config should keep previous import paths");
+    require(
+        handler.testLogLevel() == capnp_ls::LogLevel::WARNING,
+        "invalid project config should keep previous log level");
+
+    writeConfig(workspace, R"({"importPaths":["four"],"logLevel":"debug"})");
+    require(
+        !handler.testReloadProjectConfig(),
+        "unknown project config log level should not reload");
+    require(
+        handler.testImportPathCount() == 2 && handler.testImportPath(0) == "two",
+        "unknown project config log level should keep previous import paths");
+    require(
+        handler.testLogLevel() == capnp_ls::LogLevel::WARNING,
+        "unknown project config log level should keep previous log level");
 
     std::filesystem::remove(workspace / ".capnp-ls.json");
     require(handler.testReloadProjectConfig(), "deleted config should reload");
     require(
         handler.testImportPathCount() == 0,
         "deleted project config should clear import paths");
+    require(
+        handler.testLogLevel() == capnp_ls::LogLevel::WARNING,
+        "deleted project config should restore default log level");
   }
 
   {

--- a/tests/initialize_config_test.cpp
+++ b/tests/initialize_config_test.cpp
@@ -204,13 +204,19 @@ int main() {
         "initial log level should load from project config");
 
     writeConfig(workspace, R"({"importPaths":["two","three"],"logLevel":"warning"})");
-    require(handler.testReloadProjectConfig(), "valid config change should reload");
+    auto configPathString = (workspace / ".capnp-ls.json").string();
+    handler
+        .handleMessage(lspMessage(kj::str(
+            R"({"jsonrpc":"2.0","method":"workspace/didChangeWatchedFiles","params":{"changes":[{"uri":"file://)",
+            configPathString.c_str(),
+            R"(","type":2}]}})")))
+        .wait(io.waitScope);
     require(
         handler.testImportPathCount() == 2 && handler.testImportPath(0) == "two",
-        "changed project config should replace import paths");
+        "watched file change should reload project config import paths");
     require(
         handler.testLogLevel() == capnp_ls::LogLevel::WARNING,
-        "changed project config should replace log level");
+        "watched file change should reload project config log level");
 
     writeConfig(workspace, R"({"importPaths":[)");
     require(!handler.testReloadProjectConfig(), "invalid config should not reload");

--- a/tests/initialize_config_test.cpp
+++ b/tests/initialize_config_test.cpp
@@ -87,10 +87,19 @@ void writeConfig(const std::filesystem::path &workspace, kj::StringPtr content) 
   output.write(content.begin(), content.size());
 }
 
+void writeSchema(const std::filesystem::path &path, kj::StringPtr content) {
+  std::ofstream output(path);
+  output.write(content.begin(), content.size());
+}
+
 void decodeJson(kj::StringPtr json, capnp::MallocMessageBuilder &builder) {
   capnp::JsonCodec codec;
   auto root = builder.initRoot<capnp::JsonValue>();
   codec.decodeRaw(kj::arrayPtr(json.begin(), json.size()), root);
+}
+
+kj::String lspMessage(kj::StringPtr json) {
+  return kj::str("Content-Length: ", json.size(), "\r\n\r\n", json);
 }
 
 kj::StringPtr responseJson(kj::StringPtr message) {
@@ -252,6 +261,72 @@ int main() {
     require(
         handler.testImportPath(0) == "override",
         "initialization option import path should be preserved");
+  }
+
+  {
+    auto workspace = makeTempWorkspace();
+    KJ_DEFER(std::filesystem::remove_all(workspace));
+    auto schemaPath = workspace / "syntax.capnp";
+    auto schemaPathString = schemaPath.string();
+    writeSchema(
+        schemaPath,
+        R"(@0xdba53d6c0e9fe303;
+const defaultName :Text = "Ada";
+struct Person {
+  name @0 :Text = defaultName;
+}
+)");
+
+    auto stream = kj::heap<CapturingOutputStream>();
+    auto &captured = *stream;
+    capnp_ls::StdoutWriter writer(kj::mv(stream));
+    capnp_ls::LspMessageHandler handler(context, writer);
+
+    capnp::MallocMessageBuilder params;
+    auto workspaceString = workspace.string();
+    decodeJson(kj::str(
+        R"({"workspaceFolders":[{"uri":"file://)",
+        workspaceString.c_str(),
+        R"("}]})"),
+        params);
+    capnp::MallocMessageBuilder response;
+    handler
+        .testHandleInitialize(params.getRoot<capnp::JsonValue>().asReader(), response)
+        .wait(io.waitScope);
+
+    handler
+        .handleMessage(lspMessage(kj::str(
+            R"({"jsonrpc":"2.0","method":"textDocument/didOpen","params":{"textDocument":{"uri":"file://)",
+            schemaPathString.c_str(),
+            R"("}}})")))
+        .wait(io.waitScope);
+    require(
+        captured.output.find("Constant names must be qualified") !=
+            std::string::npos,
+        "invalid schema should publish a compiler diagnostic");
+
+    captured.output.clear();
+    writeSchema(
+        schemaPath,
+        R"(@0xdba53d6c0e9fe303;
+const defaultName :Text = "Ada";
+struct Person {
+  name @0 :Text = .defaultName;
+}
+)");
+    handler
+        .handleMessage(lspMessage(kj::str(
+            R"({"jsonrpc":"2.0","method":"textDocument/didSave","params":{"textDocument":{"uri":"file://)",
+            schemaPathString.c_str(),
+            R"("}}})")))
+        .wait(io.waitScope);
+    require(
+        captured.output.find(R"("diagnostics":[])") != std::string::npos,
+        "fixed schema should clear previous diagnostics");
+    require(
+        captured.output.find("Constant names must be qualified") ==
+            std::string::npos,
+        "fixed schema should not republish the previous diagnostic");
   }
 
   {

--- a/tests/linked_compiler_test.cpp
+++ b/tests/linked_compiler_test.cpp
@@ -9,10 +9,8 @@
 #include "project_config.h"
 #include "symbol_resolver.h"
 #include <capnp/schema.capnp.h>
-#include <cstdlib>
 #include <kj/debug.h>
 #include <kj/string.h>
-#include <string>
 
 namespace {
 
@@ -59,27 +57,6 @@ void requireDiagnosticContaining(
 } // namespace
 
 int main() {
-  const char *previousLogEnv = std::getenv("CPP_LOG");
-  bool hadPreviousLogEnv = previousLogEnv != nullptr;
-  std::string previousLogEnvValue = hadPreviousLogEnv ? previousLogEnv : "";
-  unsetenv("CPP_LOG");
-  require(
-      capnp_ls::logLevelFromEnvironment() == capnp_ls::LogLevel::WARNING,
-      "server log level should default to warning");
-  setenv("CPP_LOG", "lsp_server=info", 1);
-  require(
-      capnp_ls::logLevelFromEnvironment() == capnp_ls::LogLevel::INFO,
-      "server log level should use explicit info from CPP_LOG");
-  setenv("CPP_LOG", "lsp_server=debug", 1);
-  require(
-      capnp_ls::logLevelFromEnvironment() == capnp_ls::LogLevel::WARNING,
-      "unknown CPP_LOG level should fall back to warning");
-  if (hadPreviousLogEnv) {
-    setenv("CPP_LOG", previousLogEnvValue.c_str(), 1);
-  } else {
-    unsetenv("CPP_LOG");
-  }
-
   kj::Vector<kj::String> importPaths;
   importPaths.add(kj::heapString("schemas/common"));
 

--- a/tests/linked_compiler_test.cpp
+++ b/tests/linked_compiler_test.cpp
@@ -5,11 +5,14 @@
 
 #include "linked_compiler.h"
 #include "kj_compat.h"
+#include "log_level.h"
 #include "project_config.h"
 #include "symbol_resolver.h"
 #include <capnp/schema.capnp.h>
+#include <cstdlib>
 #include <kj/debug.h>
 #include <kj/string.h>
+#include <string>
 
 namespace {
 
@@ -56,6 +59,27 @@ void requireDiagnosticContaining(
 } // namespace
 
 int main() {
+  const char *previousLogEnv = std::getenv("CPP_LOG");
+  bool hadPreviousLogEnv = previousLogEnv != nullptr;
+  std::string previousLogEnvValue = hadPreviousLogEnv ? previousLogEnv : "";
+  unsetenv("CPP_LOG");
+  require(
+      capnp_ls::logLevelFromEnvironment() == capnp_ls::LogLevel::WARNING,
+      "server log level should default to warning");
+  setenv("CPP_LOG", "lsp_server=info", 1);
+  require(
+      capnp_ls::logLevelFromEnvironment() == capnp_ls::LogLevel::INFO,
+      "server log level should use explicit info from CPP_LOG");
+  setenv("CPP_LOG", "lsp_server=debug", 1);
+  require(
+      capnp_ls::logLevelFromEnvironment() == capnp_ls::LogLevel::WARNING,
+      "unknown CPP_LOG level should fall back to warning");
+  if (hadPreviousLogEnv) {
+    setenv("CPP_LOG", previousLogEnvValue.c_str(), 1);
+  } else {
+    unsetenv("CPP_LOG");
+  }
+
   kj::Vector<kj::String> importPaths;
   importPaths.add(kj::heapString("schemas/common"));
 
@@ -71,6 +95,30 @@ int main() {
   require(
       configuredImportPaths[0] == "schemas/common",
       "project config should preserve import path order");
+
+  capnp_ls::ProjectConfig parsedConfig;
+  capnp_ls::parseProjectConfig(
+      R"({"importPaths":["schemas/common"],"logLevel":"info"})",
+      parsedConfig);
+  require(
+      parsedConfig.importPaths.size() == 1,
+      "project config should parse import paths");
+  require(
+      KJ_ASSERT_NONNULL(parsedConfig.logLevel) == capnp_ls::LogLevel::INFO,
+      "project config should parse log level");
+
+  bool invalidLogLevelFailed = false;
+  try {
+    capnp_ls::ProjectConfig invalidConfig;
+    capnp_ls::parseProjectConfig(
+        R"({"importPaths":["schemas/common"],"logLevel":"debug"})",
+        invalidConfig);
+  } catch (kj::Exception &) {
+    invalidLogLevelFailed = true;
+  }
+  require(
+      invalidLogLevelFailed,
+      "project config should reject unknown log levels");
 
   kj::HashMap<kj::String, kj::Vector<capnp_ls::Diagnostic>> diagnostics;
 


### PR DESCRIPTION
## Summary
- add .capnp-ls.json logLevel support for workspace-specific logging
- keep the server default log level at warning
- remove CPP_LOG-based log level fallback handling
- handle workspace/didChangeWatchedFiles so .capnp-ls.json edits reload logLevel/importPaths without restart
- remove the E2E test setting that forced CPP_LOG=lsp_server=info
- clear stale diagnostics after a previously invalid schema compiles successfully
- document logLevel in README and VS Code sample docs

## Tests
- just test
- pnpm --dir samples compile
- pnpm --dir samples test