### PR TITLE
Add hover references and document symbols

### DIFF
--- a/samples/client/src/test/server.test.ts
+++ b/samples/client/src/test/server.test.ts
@@ -99,4 +99,74 @@ suite('Cap\'n Proto Language Server Test Suite', () => {
         assert.strictEqual(definitions[0].range.start.line, 17, 'Definition should be at line 18 (0-indexed)');
         assert.strictEqual(definitions[0].range.start.character, 2, 'Definition should start at character 3');
     });
+
+    test('Hover Provider', async () => {
+        const workspaceFolder = vscode.workspace.workspaceFolders![0];
+        const uri = vscode.Uri.file(path.join(workspaceFolder.uri.fsPath, 'schemas/company.capnp'));
+        document = await vscode.workspace.openTextDocument(uri);
+        await vscode.window.showTextDocument(document);
+
+        await new Promise(resolve => setTimeout(resolve, 2000));
+
+        const hovers = await vscode.commands.executeCommand<vscode.Hover[]>(
+            'vscode.executeHoverProvider',
+            document.uri,
+            new vscode.Position(14, 28)
+        );
+
+        assert.ok(hovers?.length > 0, 'No hover found');
+        const markdown = hovers[0].contents
+            .map(content => typeof content === 'string' ? content : content.value)
+            .join('\n');
+        assert.ok(markdown.includes('struct Employee'), 'Hover should include symbol metadata');
+    });
+
+    test('Document Symbol Provider', async () => {
+        const workspaceFolder = vscode.workspace.workspaceFolders![0];
+        const uri = vscode.Uri.file(path.join(workspaceFolder.uri.fsPath, 'schemas/company.capnp'));
+        document = await vscode.workspace.openTextDocument(uri);
+        await vscode.window.showTextDocument(document);
+
+        await new Promise(resolve => setTimeout(resolve, 2000));
+
+        const symbols = await vscode.commands.executeCommand<vscode.DocumentSymbol[]>(
+            'vscode.executeDocumentSymbolProvider',
+            document.uri
+        );
+
+        assert.ok(symbols?.length > 0, 'No document symbols found');
+        assert.ok(
+            symbols.some(symbol => symbol.name === 'EmployeeManagement'),
+            'Document symbols should include the interface'
+        );
+        assert.ok(
+            symbols.some(symbol => symbol.name === 'Employee'),
+            'Document symbols should include the nested struct'
+        );
+        assert.ok(
+            symbols.some(symbol => symbol.name === 'addEmployee'),
+            'Document symbols should include methods'
+        );
+    });
+
+    test('Reference Provider', async () => {
+        const workspaceFolder = vscode.workspace.workspaceFolders![0];
+        const uri = vscode.Uri.file(path.join(workspaceFolder.uri.fsPath, 'schemas/company.capnp'));
+        document = await vscode.workspace.openTextDocument(uri);
+        await vscode.window.showTextDocument(document);
+
+        await new Promise(resolve => setTimeout(resolve, 2000));
+
+        const references = await vscode.commands.executeCommand<vscode.Location[]>(
+            'vscode.executeReferenceProvider',
+            document.uri,
+            new vscode.Position(14, 28)
+        );
+
+        assert.ok(references?.length > 1, 'References should include declaration and usages');
+        assert.ok(
+            references.some(reference => reference.range.start.line === 17),
+            'References should include the declaration'
+        );
+    });
 });

--- a/src/compilation_manager.cpp
+++ b/src/compilation_manager.cpp
@@ -35,6 +35,9 @@ kj::Promise<void> CompilationManager::compile(CompileParams params) {
           request,
           params.fileSourceInfoMap,
           params.nodeLocationMap,
+          params.nodeMetadataMap,
+          params.referenceMap,
+          params.documentSymbolMap,
           params.importPaths,
           params.workingDir);
     }

--- a/src/compilation_manager.h
+++ b/src/compilation_manager.h
@@ -27,12 +27,18 @@ public:
         kj::StringPtr workingDir,
         kj::HashMap<kj::String, kj::HashMap<Range, uint64_t>> &fileSourceInfoMap,
         kj::HashMap<uint64_t, kj::Own<Location>> &nodeLocationMap,
+        kj::HashMap<uint64_t, kj::Own<SymbolMetadata>> &nodeMetadataMap,
+        kj::HashMap<uint64_t, kj::Vector<Location>> &referenceMap,
+        kj::HashMap<kj::String, kj::Vector<DocumentSymbol>> &documentSymbolMap,
         kj::HashMap<kj::String, kj::Vector<Diagnostic>> &diagnosticMap)
         : importPaths(importPaths),
           fileName(fileName),
           workingDir(workingDir),
           fileSourceInfoMap(fileSourceInfoMap),
           nodeLocationMap(nodeLocationMap),
+          nodeMetadataMap(nodeMetadataMap),
+          referenceMap(referenceMap),
+          documentSymbolMap(documentSymbolMap),
           diagnosticMap(diagnosticMap) {}
 
     const kj::Vector<kj::String> &importPaths;
@@ -40,6 +46,9 @@ public:
     kj::StringPtr workingDir;
     kj::HashMap<kj::String, kj::HashMap<Range, uint64_t>> &fileSourceInfoMap;
     kj::HashMap<uint64_t, kj::Own<Location>> &nodeLocationMap;
+    kj::HashMap<uint64_t, kj::Own<SymbolMetadata>> &nodeMetadataMap;
+    kj::HashMap<uint64_t, kj::Vector<Location>> &referenceMap;
+    kj::HashMap<kj::String, kj::Vector<DocumentSymbol>> &documentSymbolMap;
     kj::HashMap<kj::String, kj::Vector<Diagnostic>> &diagnosticMap;
   };
 

--- a/src/lsp_message_handler.cpp
+++ b/src/lsp_message_handler.cpp
@@ -16,6 +16,110 @@
 #include <unistd.h>
 
 namespace capnp_ls {
+namespace {
+
+struct TextDocumentPosition {
+  kj::String uri;
+  kj::String path;
+  uint32_t line = 0;
+  uint32_t character = 0;
+};
+
+void setPosition(capnp::JsonValue::Builder value, const Position &position) {
+  auto obj = value.initObject(2);
+  obj[0].setName("line");
+  obj[0].getValue().setNumber(position.line - 1);
+  obj[1].setName("character");
+  obj[1].getValue().setNumber(position.character - 1);
+}
+
+void setRange(capnp::JsonValue::Builder value, const Range &range) {
+  auto rangeObj = value.initObject(2);
+  rangeObj[0].setName("start");
+  setPosition(rangeObj[0].getValue(), range.start);
+  rangeObj[1].setName("end");
+  setPosition(rangeObj[1].getValue(), range.end);
+}
+
+void setLocation(capnp::JsonValue::Builder value, const Location &location) {
+  auto locationObj = value.initObject(2);
+  locationObj[0].setName("uri");
+  locationObj[0].getValue().setString(kj::str("file://", location.uri));
+  locationObj[1].setName("range");
+  setRange(locationObj[1].getValue(), location.range);
+}
+
+TextDocumentPosition parseTextDocumentPosition(
+    const capnp::JsonValue::Reader &params) {
+  auto paramsObj = params.getObject();
+  TextDocumentPosition parsed;
+
+  for (auto field : paramsObj) {
+    if (field.getName() == "textDocument") {
+      auto textDocument = field.getValue().getObject();
+      for (auto docField : textDocument) {
+        if (docField.getName() == "uri") {
+          parsed.uri = kj::heapString(docField.getValue().getString());
+          parsed.path = uriToPath(parsed.uri);
+        }
+      }
+    } else if (field.getName() == "position") {
+      auto position = field.getValue().getObject();
+      for (auto posField : position) {
+        if (posField.getName() == "line") {
+          parsed.line = posField.getValue().getNumber() + 1;
+        } else if (posField.getName() == "character") {
+          parsed.character = posField.getValue().getNumber() + 1;
+        }
+      }
+    }
+  }
+
+  return parsed;
+}
+
+kj::String parseTextDocumentPath(const capnp::JsonValue::Reader &params) {
+  auto paramsObj = params.getObject();
+  for (auto field : paramsObj) {
+    if (field.getName() == "textDocument") {
+      auto textDocument = field.getValue().getObject();
+      for (auto docField : textDocument) {
+        if (docField.getName() == "uri") {
+          return uriToPath(docField.getValue().getString());
+        }
+      }
+    }
+  }
+  return kj::heapString("");
+}
+
+bool containsPosition(const Range &range, uint32_t line, uint32_t character) {
+  if (line < range.start.line || line > range.end.line) {
+    return false;
+  }
+  if (line == range.start.line && character < range.start.character) {
+    return false;
+  }
+  if (line == range.end.line && character > range.end.character) {
+    return false;
+  }
+  return true;
+}
+
+bool isTighterRange(const Range &candidate, const Range &best) {
+  uint32_t candidateLineSpan = candidate.end.line - candidate.start.line;
+  uint32_t bestLineSpan = best.end.line - best.start.line;
+  if (candidateLineSpan != bestLineSpan) {
+    return candidateLineSpan < bestLineSpan;
+  }
+  int64_t candidateCharSpan = static_cast<int64_t>(candidate.end.character) -
+      static_cast<int64_t>(candidate.start.character);
+  int64_t bestCharSpan = static_cast<int64_t>(best.end.character) -
+      static_cast<int64_t>(best.start.character);
+  return candidateCharSpan < bestCharSpan;
+}
+
+} // namespace
 
 LspMessageHandler::LspMessageHandler(
     ServerContext &serverContext,
@@ -81,6 +185,15 @@ LspMessageHandler::handleMessage(kj::Maybe<kj::String> maybeMessage) {
         case LspMethod::DEFINITION:
           promise = handleDefinition(params, *responseMessageBuilder);
           break;
+        case LspMethod::HOVER:
+          promise = handleHover(params, *responseMessageBuilder);
+          break;
+        case LspMethod::REFERENCES:
+          promise = handleReferences(params, *responseMessageBuilder);
+          break;
+        case LspMethod::DOCUMENT_SYMBOL:
+          promise = handleDocumentSymbol(params, *responseMessageBuilder);
+          break;
         case LspMethod::DID_OPEN:
           promise = handleDidOpenTextDocument(params);
           break;
@@ -141,6 +254,9 @@ LspMessageHandler::handleMessage(kj::Maybe<kj::String> maybeMessage) {
 void LspMessageHandler::clearCompilationState() {
   fileSourceInfoMap.clear();
   nodeLocationMap.clear();
+  nodeMetadataMap.clear();
+  referenceMap.clear();
+  documentSymbolMap.clear();
   diagnosticMap.clear();
 }
 
@@ -208,11 +324,23 @@ kj::Maybe<kj::String> LspMessageHandler::buildResponseString(
     obj[1].getValue().setNumber(id);
 
     obj[2].setName(LSP_RESULT);
-    if (result.isObject() && result.getObject().size() > 0 &&
-        result.getObject()[0].getValue().isObject()) {
-      obj[2].getValue().setObject(result.getObject()[0].getValue().getObject());
-    } else {
+    if (!result.isObject() || result.getObject().size() == 0) {
       obj[2].getValue().setNull();
+    } else {
+      auto resultValue = result.getObject()[0].getValue();
+      if (resultValue.isObject()) {
+        obj[2].getValue().setObject(resultValue.getObject());
+      } else if (resultValue.isArray()) {
+        obj[2].getValue().setArray(resultValue.getArray());
+      } else if (resultValue.isString()) {
+        obj[2].getValue().setString(resultValue.getString());
+      } else if (resultValue.isNumber()) {
+        obj[2].getValue().setNumber(resultValue.getNumber());
+      } else if (resultValue.isBoolean()) {
+        obj[2].getValue().setBoolean(resultValue.getBoolean());
+      } else {
+        obj[2].getValue().setNull();
+      }
     }
 
     capnp::JsonCodec codec;
@@ -285,6 +413,9 @@ kj::Promise<void> LspMessageHandler::compileCapnpFile(kj::StringPtr uri) {
             workspacePath,
             fileSourceInfoMap,
             nodeLocationMap,
+            nodeMetadataMap,
+            referenceMap,
+            documentSymbolMap,
             diagnosticMap))
         .then([this,
                strippedUri = kj::mv(strippedUri),
@@ -424,6 +555,34 @@ kj::Promise<void> LspMessageHandler::handleShutdown() {
   return kj::READY_NOW;
 }
 
+kj::Maybe<uint64_t> LspMessageHandler::findNodeIdAtPosition(
+    kj::StringPtr path,
+    uint32_t line,
+    uint32_t character) {
+  CAPNP_LS_IF_SOME (rangeMap, fileSourceInfoMap.find(path)) {
+    for (const auto &[range, id] : *rangeMap) {
+      if (containsPosition(range, line, character)) {
+        return id;
+      }
+    }
+  }
+
+  // Fall back to declaration ranges, picking the most deeply nested one.
+  kj::Maybe<uint64_t> bestId = CAPNP_LS_NONE;
+  const Range *bestRange = nullptr;
+  for (const auto &[id, location] : nodeLocationMap) {
+    if (location->uri != path ||
+        !containsPosition(location->range, line, character)) {
+      continue;
+    }
+    if (bestRange == nullptr || isTighterRange(location->range, *bestRange)) {
+      bestId = id;
+      bestRange = &location->range;
+    }
+  }
+  return bestId;
+}
+
 kj::Promise<void> LspMessageHandler::handleDefinition(
     const capnp::JsonValue::Reader &params,
     capnp::MallocMessageBuilder &definitionResponseBuilder) {
@@ -435,109 +594,173 @@ kj::Promise<void> LspMessageHandler::handleDefinition(
   resultField.setName(LSP_RESULT);
 
   try {
-    auto paramsObj = params.getObject();
-    kj::String uri;
-    uint32_t line = 0;
-    uint32_t character = 0;
+    auto position = parseTextDocumentPosition(params);
+    auto maybeId =
+        findNodeIdAtPosition(position.path, position.line, position.character);
 
-    KJ_LOG(INFO, "Parsing parameters");
-
-    for (auto field : paramsObj) {
-      if (field.getName() == "textDocument") {
-        auto textDocument = field.getValue().getObject();
-        for (auto docField : textDocument) {
-          if (docField.getName() == "uri") {
-            uri = kj::heapString(docField.getValue().getString());
-            KJ_LOG(INFO, "Found URI", uri);
-          }
-        }
-      } else if (field.getName() == "position") {
-        auto position = field.getValue().getObject();
-        for (auto posField : position) {
-          if (posField.getName() == "line") {
-            line = posField.getValue().getNumber() + 1;
-            KJ_LOG(INFO, "Found", line);
-          } else if (posField.getName() == "character") {
-            character = posField.getValue().getNumber() + 1;
-            KJ_LOG(INFO, "Found", character);
-          }
-        }
+    CAPNP_LS_IF_SOME (id, maybeId) {
+      CAPNP_LS_IF_SOME (location, nodeLocationMap.find(*id)) {
+        setLocation(resultField.getValue(), **location);
+        return kj::READY_NOW;
       }
     }
-
-    // erase file:// prefix and workspacePath from uri
-    kj::String strippedUri = uriToPath(uri);
-
-    KJ_LOG(
-        INFO,
-        "Definition request params:",
-        strippedUri.cStr(),
-        line,
-        character);
-
-    CAPNP_LS_IF_SOME (rangeMap, fileSourceInfoMap.find(strippedUri)) {
-      for (const auto &[range, id] : *rangeMap) {
-        if (range.start.line <= line && line <= range.end.line &&
-            range.start.character <= character &&
-            character <= range.end.character) {
-
-          KJ_LOG(INFO, "Found range for ", id);
-
-          CAPNP_LS_IF_SOME (location, nodeLocationMap.find(id)) {
-            KJ_LOG(INFO, "Found location");
-
-            auto locationObj = resultField.getValue().initObject(2);
-
-            // Uri
-            auto uriField = locationObj[0];
-            uriField.setName("uri");
-            kj::String fullUri = kj::str("file://", (*location)->uri);
-            uriField.getValue().setString(fullUri);
-
-            // Range
-            auto rangeField = locationObj[1];
-            rangeField.setName("range");
-            auto rangeObj = rangeField.getValue().initObject(2);
-
-            // Start position
-            auto startField = rangeObj[0];
-            startField.setName("start");
-            auto startObj = startField.getValue().initObject(2);
-            startObj[0].setName("line");
-            startObj[0].getValue().setNumber((*location)->range.start.line - 1);
-            startObj[1].setName("character");
-            startObj[1].getValue().setNumber(
-                (*location)->range.start.character - 1);
-
-            auto endField = rangeObj[1];
-            endField.setName("end");
-            auto endObj = endField.getValue().initObject(2);
-            endObj[0].setName("line");
-            endObj[0].getValue().setNumber((*location)->range.end.line - 1);
-            endObj[1].setName("character");
-            endObj[1].getValue().setNumber(
-                (*location)->range.end.character - 1);
-
-            KJ_LOG(INFO, "Response structure complete");
-            return kj::READY_NOW;
-          }
-        }
-      }
-    } else {
-      KJ_LOG(
-          INFO,
-          kj::str(
-              "SourceInfo not found for ",
-              strippedUri,
-              ". The file may still be compiling or compilation may have failed."));
-    }
-
-    resultField.getValue().setNull();
   } catch (kj::Exception &e) {
     KJ_LOG(ERROR, "Error processing definition request", e.getDescription());
-    resultField.getValue().setNull();
   }
 
+  resultField.getValue().setNull();
+  return kj::READY_NOW;
+}
+
+kj::Promise<void> LspMessageHandler::handleHover(
+    const capnp::JsonValue::Reader &params,
+    capnp::MallocMessageBuilder &hoverResponseBuilder) {
+  KJ_LOG(INFO, "Handling hover request");
+
+  auto root = hoverResponseBuilder.initRoot<capnp::JsonValue>();
+  auto resultObj = root.initObject(1);
+  auto resultField = resultObj[0];
+  resultField.setName(LSP_RESULT);
+
+  try {
+    auto position = parseTextDocumentPosition(params);
+    auto maybeId =
+        findNodeIdAtPosition(position.path, position.line, position.character);
+
+    CAPNP_LS_IF_SOME (id, maybeId) {
+      CAPNP_LS_IF_SOME (metadata, nodeMetadataMap.find(*id)) {
+        auto hoverObj = resultField.getValue().initObject(1);
+        hoverObj[0].setName("contents");
+        auto contents = hoverObj[0].getValue().initObject(2);
+        contents[0].setName("kind");
+        contents[0].getValue().setString("markdown");
+        contents[1].setName("value");
+        auto value = (*metadata)->documentation.size() > 0
+            ? kj::str(
+                  "```capnp\n",
+                  (*metadata)->detail,
+                  " ",
+                  (*metadata)->name,
+                  "\n```\n",
+                  (*metadata)->documentation)
+            : kj::str(
+                  "```capnp\n",
+                  (*metadata)->detail,
+                  " ",
+                  (*metadata)->name,
+                  "\n```");
+        contents[1].getValue().setString(value);
+        return kj::READY_NOW;
+      }
+    }
+  } catch (kj::Exception &e) {
+    KJ_LOG(ERROR, "Error processing hover request", e.getDescription());
+  }
+
+  resultField.getValue().setNull();
+  return kj::READY_NOW;
+}
+
+kj::Promise<void> LspMessageHandler::handleReferences(
+    const capnp::JsonValue::Reader &params,
+    capnp::MallocMessageBuilder &referencesResponseBuilder) {
+  KJ_LOG(INFO, "Handling references request");
+
+  auto root = referencesResponseBuilder.initRoot<capnp::JsonValue>();
+  auto resultObj = root.initObject(1);
+  auto resultField = resultObj[0];
+  resultField.setName(LSP_RESULT);
+
+  try {
+    auto position = parseTextDocumentPosition(params);
+    bool includeDeclaration = true;
+    for (auto field : params.getObject()) {
+      if (field.getName() == "context") {
+        for (auto contextField : field.getValue().getObject()) {
+          if (contextField.getName() == "includeDeclaration") {
+            includeDeclaration = contextField.getValue().getBoolean();
+          }
+        }
+      }
+    }
+
+    auto maybeId =
+        findNodeIdAtPosition(position.path, position.line, position.character);
+
+    CAPNP_LS_IF_SOME (id, maybeId) {
+      CAPNP_LS_IF_SOME (references, referenceMap.find(*id)) {
+        const Location *declaration = nullptr;
+        CAPNP_LS_IF_SOME (declarationLocation, nodeLocationMap.find(*id)) {
+          declaration = declarationLocation->get();
+        }
+
+        size_t resultSize = 0;
+        for (const auto &reference : *references) {
+          bool isDeclaration = declaration != nullptr &&
+              declaration->uri == reference.uri &&
+              declaration->range == reference.range;
+          if (includeDeclaration || !isDeclaration) {
+            ++resultSize;
+          }
+        }
+
+        auto array = resultField.getValue().initArray(resultSize);
+        size_t index = 0;
+        for (const auto &reference : *references) {
+          bool isDeclaration = declaration != nullptr &&
+              declaration->uri == reference.uri &&
+              declaration->range == reference.range;
+          if (includeDeclaration || !isDeclaration) {
+            setLocation(array[index], reference);
+            ++index;
+          }
+        }
+        return kj::READY_NOW;
+      }
+    }
+  } catch (kj::Exception &e) {
+    KJ_LOG(ERROR, "Error processing references request", e.getDescription());
+  }
+
+  resultField.getValue().initArray(0);
+  return kj::READY_NOW;
+}
+
+kj::Promise<void> LspMessageHandler::handleDocumentSymbol(
+    const capnp::JsonValue::Reader &params,
+    capnp::MallocMessageBuilder &documentSymbolResponseBuilder) {
+  KJ_LOG(INFO, "Handling documentSymbol request");
+
+  auto root = documentSymbolResponseBuilder.initRoot<capnp::JsonValue>();
+  auto resultObj = root.initObject(1);
+  auto resultField = resultObj[0];
+  resultField.setName(LSP_RESULT);
+
+  try {
+    auto path = parseTextDocumentPath(params);
+    CAPNP_LS_IF_SOME (symbols, documentSymbolMap.find(path)) {
+      auto array = resultField.getValue().initArray(symbols->size());
+      for (size_t i = 0; i < symbols->size(); ++i) {
+        const auto &symbol = (*symbols)[i];
+        auto symbolObj = array[i].initObject(5);
+        symbolObj[0].setName("name");
+        symbolObj[0].getValue().setString(symbol.name);
+        symbolObj[1].setName("detail");
+        symbolObj[1].getValue().setString(symbol.detail);
+        symbolObj[2].setName("kind");
+        symbolObj[2].getValue().setNumber(symbol.kind);
+        symbolObj[3].setName("range");
+        setRange(symbolObj[3].getValue(), symbol.range);
+        symbolObj[4].setName("selectionRange");
+        setRange(symbolObj[4].getValue(), symbol.selectionRange);
+      }
+      return kj::READY_NOW;
+    }
+  } catch (kj::Exception &e) {
+    KJ_LOG(ERROR, "Error processing documentSymbol request", e.getDescription());
+  }
+
+  resultField.getValue().initArray(0);
   return kj::READY_NOW;
 }
 
@@ -671,7 +894,7 @@ kj::Promise<void> LspMessageHandler::handleInitialize(
   auto capsField = resultValue[0];
   capsField.setName("capabilities");
 
-  auto capabilities = capsField.getValue().initObject(3);
+  auto capabilities = capsField.getValue().initObject(6);
 
   // Set text document sync capability
   auto syncField = capabilities[0];
@@ -699,6 +922,18 @@ kj::Promise<void> LspMessageHandler::handleInitialize(
   auto watchedFilesField = capabilities[2];
   watchedFilesField.setName("workspace/didChangeWatchedFiles");
   watchedFilesField.getValue().setBoolean(true);
+
+  auto hoverField = capabilities[3];
+  hoverField.setName("hoverProvider");
+  hoverField.getValue().setBoolean(true);
+
+  auto referencesField = capabilities[4];
+  referencesField.setName("referencesProvider");
+  referencesField.getValue().setBoolean(true);
+
+  auto documentSymbolField = capabilities[5];
+  documentSymbolField.setName("documentSymbolProvider");
+  documentSymbolField.getValue().setBoolean(true);
 
   return kj::READY_NOW;
 }

--- a/src/lsp_message_handler.h
+++ b/src/lsp_message_handler.h
@@ -56,6 +56,15 @@ private:
   kj::Promise<void> handleDefinition(
       const capnp::JsonValue::Reader &params,
       capnp::MallocMessageBuilder &definitionResponseBuilder);
+  kj::Promise<void> handleHover(
+      const capnp::JsonValue::Reader &params,
+      capnp::MallocMessageBuilder &hoverResponseBuilder);
+  kj::Promise<void> handleReferences(
+      const capnp::JsonValue::Reader &params,
+      capnp::MallocMessageBuilder &referencesResponseBuilder);
+  kj::Promise<void> handleDocumentSymbol(
+      const capnp::JsonValue::Reader &params,
+      capnp::MallocMessageBuilder &documentSymbolResponseBuilder);
   kj::Promise<void>
   handleDidChangeWatchedFiles(const capnp::JsonValue::Reader &params);
   kj::Promise<void> handleDidSave(const capnp::JsonValue::Reader &params);
@@ -76,9 +85,14 @@ private:
   bool reloadProjectConfig();
   void clearCompilationState();
   bool isProjectConfigPath(kj::StringPtr path);
+  kj::Maybe<uint64_t>
+  findNodeIdAtPosition(kj::StringPtr path, uint32_t line, uint32_t character);
 
   kj::HashMap<kj::String, kj::HashMap<Range, uint64_t>> fileSourceInfoMap;
   kj::HashMap<uint64_t, kj::Own<Location>> nodeLocationMap;
+  kj::HashMap<uint64_t, kj::Own<SymbolMetadata>> nodeMetadataMap;
+  kj::HashMap<uint64_t, kj::Vector<Location>> referenceMap;
+  kj::HashMap<kj::String, kj::Vector<DocumentSymbol>> documentSymbolMap;
   kj::HashMap<kj::String, kj::Vector<Diagnostic>> diagnosticMap;
   kj::String workspacePath;
   kj::Vector<kj::String> importPaths;

--- a/src/lsp_types.h
+++ b/src/lsp_types.h
@@ -32,6 +32,9 @@ constexpr const char LSP_ERROR[] = "error";
   MACRO(INITIALIZE, "initialize")                                              \
   MACRO(SHUTDOWN, "shutdown")                                                  \
   MACRO(DEFINITION, "textDocument/definition")                                 \
+  MACRO(HOVER, "textDocument/hover")                                           \
+  MACRO(REFERENCES, "textDocument/references")                                 \
+  MACRO(DOCUMENT_SYMBOL, "textDocument/documentSymbol")                        \
   MACRO(DID_OPEN, "textDocument/didOpen")                                      \
   MACRO(DID_CHANGE_WATCHED_FILES, "workspace/didChangeWatchedFiles")           \
   MACRO(DID_SAVE, "textDocument/didSave")                                      \
@@ -78,6 +81,20 @@ struct Range {
 struct Location {
   kj::String uri;
   Range range;
+};
+
+struct SymbolMetadata {
+  kj::String name;
+  kj::String detail;
+  kj::String documentation;
+};
+
+struct DocumentSymbol {
+  kj::String name;
+  kj::String detail;
+  uint32_t kind;
+  Range range;
+  Range selectionRange;
 };
 
 enum class DiagnosticSeverity {

--- a/src/symbol_resolver.cpp
+++ b/src/symbol_resolver.cpp
@@ -37,30 +37,220 @@ struct TypeInfo {
   kj::String typeName;
 };
 
-Position getPositionInFile(kj::StringPtr filePath, size_t byteOffset) {
-  auto fs = kj::newDiskFilesystem();
-
-  const kj::Directory &rootDir = fs->getRoot();
-  auto file = rootDir.openFile(kj::Path::parse(filePath.slice(1)));
-
-  Position pos = {1, 1};
-
-  if (byteOffset == 0) {
-    return pos;
+// Converts byte offsets to positions, reading each file once per instance.
+class PositionCalculator {
+public:
+  Position getPosition(kj::StringPtr filePath, size_t byteOffset) {
+    auto &table = lineTables.findOrCreate(
+        filePath,
+        [&]() -> kj::HashMap<kj::String, LineTable>::Entry {
+          return {kj::heapString(filePath), buildLineTable(filePath)};
+        });
+    size_t offset = kj::min(byteOffset, table.contentSize);
+    size_t lineIndex = 0;
+    size_t end = table.lineStarts.size();
+    while (lineIndex + 1 < end) {
+      size_t mid = lineIndex + (end - lineIndex) / 2;
+      if (table.lineStarts[mid] <= offset) {
+        lineIndex = mid;
+      } else {
+        end = mid;
+      }
+    }
+    return Position{
+        static_cast<uint32_t>(lineIndex + 1),
+        static_cast<uint32_t>(offset - table.lineStarts[lineIndex] + 1)};
   }
 
-  auto content = file->readAllText();
+private:
+  struct LineTable {
+    kj::Vector<size_t> lineStarts;
+    size_t contentSize;
+  };
 
-  for (size_t i = 0; i < byteOffset && i < content.size(); ++i) {
-    if (content[i] == '\n') {
-      pos.line++;
-      pos.character = 1;
-    } else {
-      pos.character++;
+  static LineTable buildLineTable(kj::StringPtr filePath) {
+    auto fs = kj::newDiskFilesystem();
+    auto file = fs->getRoot().openFile(kj::Path::parse(filePath.slice(1)));
+    auto content = file->readAllText();
+    kj::Vector<size_t> lineStarts;
+    lineStarts.add(0);
+    for (size_t i = 0; i < content.size(); ++i) {
+      if (content[i] == '\n') {
+        lineStarts.add(i + 1);
+      }
+    }
+    return LineTable{kj::mv(lineStarts), content.size()};
+  }
+
+  kj::HashMap<kj::String, LineTable> lineTables;
+};
+
+constexpr uint32_t LSP_SYMBOL_KIND_FILE = 1;
+constexpr uint32_t LSP_SYMBOL_KIND_METHOD = 6;
+constexpr uint32_t LSP_SYMBOL_KIND_FIELD = 8;
+constexpr uint32_t LSP_SYMBOL_KIND_ENUM = 10;
+constexpr uint32_t LSP_SYMBOL_KIND_INTERFACE = 11;
+constexpr uint32_t LSP_SYMBOL_KIND_CONSTANT = 14;
+constexpr uint32_t LSP_SYMBOL_KIND_ENUM_MEMBER = 22;
+constexpr uint32_t LSP_SYMBOL_KIND_STRUCT = 23;
+
+kj::String shortDisplayName(capnp::schema::Node::Reader node) {
+  auto displayName = node.getDisplayName();
+  auto prefixLength = node.getDisplayNamePrefixLength();
+  if (prefixLength <= displayName.size()) {
+    return kj::heapString(displayName.slice(prefixLength));
+  }
+  return kj::heapString(displayName);
+}
+
+uint32_t documentSymbolKind(capnp::schema::Node::Reader node) {
+  switch (node.which()) {
+  case capnp::schema::Node::Which::FILE:
+    return LSP_SYMBOL_KIND_FILE;
+  case capnp::schema::Node::Which::STRUCT:
+    return LSP_SYMBOL_KIND_STRUCT;
+  case capnp::schema::Node::Which::ENUM:
+    return LSP_SYMBOL_KIND_ENUM;
+  case capnp::schema::Node::Which::INTERFACE:
+    return LSP_SYMBOL_KIND_INTERFACE;
+  case capnp::schema::Node::Which::CONST:
+    return LSP_SYMBOL_KIND_CONSTANT;
+  case capnp::schema::Node::Which::ANNOTATION:
+    return LSP_SYMBOL_KIND_CONSTANT;
+  default:
+    return LSP_SYMBOL_KIND_FIELD;
+  }
+}
+
+kj::String nodeKindName(capnp::schema::Node::Reader node) {
+  switch (node.which()) {
+  case capnp::schema::Node::Which::FILE:
+    return kj::heapString("file");
+  case capnp::schema::Node::Which::STRUCT:
+    return node.getStruct().getIsGroup() ? kj::heapString("group")
+                                         : kj::heapString("struct");
+  case capnp::schema::Node::Which::ENUM:
+    return kj::heapString("enum");
+  case capnp::schema::Node::Which::INTERFACE:
+    return kj::heapString("interface");
+  case capnp::schema::Node::Which::CONST:
+    return kj::heapString("const");
+  case capnp::schema::Node::Which::ANNOTATION:
+    return kj::heapString("annotation");
+  default:
+    return kj::heapString("symbol");
+  }
+}
+
+void addReference(
+    kj::HashMap<uint64_t, kj::Vector<Location>> &referenceMap,
+    uint64_t nodeId,
+    kj::StringPtr uri,
+    const Range &range) {
+  auto &references = referenceMap.findOrCreate(
+      nodeId,
+      [&]() -> kj::HashMap<uint64_t, kj::Vector<Location>>::Entry {
+        return {nodeId, kj::Vector<Location>()};
+      });
+  // Imported files are not cleared on recompile, so skip locations that are
+  // already recorded.
+  for (const auto &reference : references) {
+    if (reference.uri == uri && reference.range == range) {
+      return;
     }
   }
+  references.add(Location{kj::heapString(uri), range});
+}
 
-  return pos;
+void addDocumentSymbol(
+    kj::HashMap<kj::String, kj::Vector<DocumentSymbol>> &documentSymbolMap,
+    kj::StringPtr filePath,
+    DocumentSymbol symbol) {
+  auto &symbols = documentSymbolMap.findOrCreate(
+      filePath,
+      [&]() -> kj::HashMap<kj::String, kj::Vector<DocumentSymbol>>::Entry {
+        return {kj::heapString(filePath), kj::Vector<DocumentSymbol>()};
+      });
+  symbols.add(kj::mv(symbol));
+}
+
+void removeReferencesInFile(
+    kj::HashMap<uint64_t, kj::Vector<Location>> &referenceMap,
+    kj::StringPtr filePath) {
+  for (auto &[_, references] : referenceMap) {
+    size_t writeIndex = 0;
+    for (size_t readIndex = 0; readIndex < references.size(); ++readIndex) {
+      if (references[readIndex].uri != filePath) {
+        if (writeIndex != readIndex) {
+          references[writeIndex] = kj::mv(references[readIndex]);
+        }
+        ++writeIndex;
+      }
+    }
+    references.truncate(writeIndex);
+  }
+}
+
+void addMemberDocumentSymbols(
+    capnp::schema::Node::Reader node,
+    capnp::schema::Node::SourceInfo::Reader sourceInfo,
+    kj::StringPtr filePath,
+    kj::HashMap<kj::String, kj::Vector<DocumentSymbol>> &documentSymbolMap,
+    PositionCalculator &positionCalculator) {
+  auto members = sourceInfo.getMembers();
+
+  if (node.which() == capnp::schema::Node::Which::STRUCT) {
+    auto fields = node.getStruct().getFields();
+    auto size = kj::min(fields.size(), members.size());
+    for (uint i = 0; i < size; ++i) {
+      Range range{
+          positionCalculator.getPosition(filePath, members[i].getStartByte()),
+          positionCalculator.getPosition(filePath, members[i].getEndByte())};
+      addDocumentSymbol(
+          documentSymbolMap,
+          filePath,
+          DocumentSymbol{
+              kj::heapString(fields[i].getName()),
+              kj::heapString("field"),
+              LSP_SYMBOL_KIND_FIELD,
+              range,
+              range});
+    }
+  } else if (node.which() == capnp::schema::Node::Which::ENUM) {
+    auto enumerants = node.getEnum().getEnumerants();
+    auto size = kj::min(enumerants.size(), members.size());
+    for (uint i = 0; i < size; ++i) {
+      Range range{
+          positionCalculator.getPosition(filePath, members[i].getStartByte()),
+          positionCalculator.getPosition(filePath, members[i].getEndByte())};
+      addDocumentSymbol(
+          documentSymbolMap,
+          filePath,
+          DocumentSymbol{
+              kj::heapString(enumerants[i].getName()),
+              kj::heapString("enumerant"),
+              LSP_SYMBOL_KIND_ENUM_MEMBER,
+              range,
+              range});
+    }
+  } else if (node.which() == capnp::schema::Node::Which::INTERFACE) {
+    auto methods = node.getInterface().getMethods();
+    auto size = kj::min(methods.size(), members.size());
+    for (uint i = 0; i < size; ++i) {
+      Range range{
+          positionCalculator.getPosition(filePath, members[i].getStartByte()),
+          positionCalculator.getPosition(filePath, members[i].getEndByte())};
+      addDocumentSymbol(
+          documentSymbolMap,
+          filePath,
+          DocumentSymbol{
+              kj::heapString(methods[i].getName()),
+              kj::heapString("method"),
+              LSP_SYMBOL_KIND_METHOD,
+              range,
+              range});
+    }
+  }
 }
 
 kj::String extractFilePath(
@@ -148,6 +338,9 @@ int SymbolResolver::resolve(
     capnp::schema::CodeGeneratorRequest::Reader request,
     kj::HashMap<kj::String, kj::HashMap<Range, uint64_t>> &positionToNodeIdMap,
     kj::HashMap<uint64_t, kj::Own<Location>> &nodeLocationMap,
+    kj::HashMap<uint64_t, kj::Own<SymbolMetadata>> &nodeMetadataMap,
+    kj::HashMap<uint64_t, kj::Vector<Location>> &referenceMap,
+    kj::HashMap<kj::String, kj::Vector<DocumentSymbol>> &documentSymbolMap,
     const kj::Vector<kj::String> &importPaths,
     const kj::StringPtr &workspacePath) {
   try {
@@ -174,25 +367,76 @@ int SymbolResolver::resolve(
       sourceInfoMap.upsert(sourceInfo.getId(), sourceInfo);
     }
 
-    int depth = 1;
+    PositionCalculator positionCalculator;
+
+    // extractFilePath probes the filesystem, so resolve each display name
+    // prefix only once per request.
+    kj::HashMap<kj::String, kj::String> filePathCache;
+    auto resolveFilePath = [&](kj::StringPtr displayName) -> kj::StringPtr {
+      kj::String key;
+      CAPNP_LS_IF_SOME (pos, displayName.findFirst(':')) {
+        key = kj::heapString(displayName.slice(0, *pos));
+      } else {
+        key = kj::heapString(displayName);
+      }
+      return filePathCache.findOrCreate(
+          key,
+          [&]() -> kj::HashMap<kj::String, kj::String>::Entry {
+            return {
+                kj::mv(key),
+                extractFilePath(displayName, importPaths, workspacePath)};
+          });
+    };
+
+    // Clear stale per-file state before adding anything: node order in the
+    // request is not guaranteed, so clearing while adding could wipe data
+    // that was just added for the same file.
     for (auto node : request.getNodes()) {
       if (node.which() == capnp::schema::Node::Which::FILE) {
         CAPNP_LS_IF_SOME (sourceInfo, fileSourceInfoMap.find(node.getId())) {
-          kj::String filePath = extractFilePath(
-              node.getDisplayName(), importPaths, workspacePath);
-          // clear previous data for this file
+          kj::StringPtr filePath = resolveFilePath(node.getDisplayName());
           positionToNodeIdMap.erase(filePath);
+          documentSymbolMap.erase(filePath);
+          // Only requested files lose their references. Imported files keep
+          // theirs: identifier usages inside an imported file are only
+          // re-added when that file is compiled as a requested file.
+          removeReferencesInFile(referenceMap, filePath);
+        }
+        continue;
+      }
+      kj::StringPtr displayName = node.getDisplayName();
+      if (displayName.endsWith("$Params") || displayName.endsWith("$Results")) {
+        continue;
+      }
+      // Document symbols for this file are fully re-added below, including
+      // for imported files.
+      documentSymbolMap.erase(resolveFilePath(displayName));
+    }
+
+    for (auto node : request.getNodes()) {
+      if (node.which() == capnp::schema::Node::Which::FILE) {
+        CAPNP_LS_IF_SOME (sourceInfo, fileSourceInfoMap.find(node.getId())) {
+          kj::StringPtr filePath = resolveFilePath(node.getDisplayName());
 
           nodeLocationMap.upsert(
               node.getId(),
               kj::heap<Location>(Location{
                   kj::str(filePath), Range{Position{1, 1}, Position{1, 1}}}));
+          nodeMetadataMap.upsert(
+              node.getId(),
+              kj::heap<SymbolMetadata>(SymbolMetadata{
+                  shortDisplayName(node),
+                  nodeKindName(node),
+                  kj::heapString("")}));
 
           for (auto identifier : sourceInfo->getIdentifiers()) {
             Range range{
-                getPositionInFile(filePath, identifier.getStartByte()),
-                getPositionInFile(filePath, identifier.getEndByte())};
+                positionCalculator.getPosition(
+                    filePath, identifier.getStartByte()),
+                positionCalculator.getPosition(
+                    filePath, identifier.getEndByte())};
             Location location{kj::str(filePath), range};
+            addReference(referenceMap, identifier.getTypeId(), filePath, range);
             auto &rangeMap = positionToNodeIdMap.findOrCreate(
                 location.uri,
                 [&]() -> kj::HashMap<kj::String, kj::HashMap<Range, uint64_t>>::
@@ -212,16 +456,33 @@ int SymbolResolver::resolve(
         continue;
       }
 
-      kj::String filePath =
-          extractFilePath(displayName, importPaths, workspacePath);
+      kj::StringPtr filePath = resolveFilePath(displayName);
 
       CAPNP_LS_IF_SOME (sourceInfo, sourceInfoMap.find(node.getId())) {
         Range range{
-            getPositionInFile(filePath, sourceInfo->getStartByte()),
-            getPositionInFile(filePath, sourceInfo->getEndByte())};
+            positionCalculator.getPosition(filePath, sourceInfo->getStartByte()),
+            positionCalculator.getPosition(filePath, sourceInfo->getEndByte())};
         nodeLocationMap.upsert(
             node.getId(),
             kj::heap<Location>(Location{kj::str(filePath), range}));
+        nodeMetadataMap.upsert(
+            node.getId(),
+            kj::heap<SymbolMetadata>(SymbolMetadata{
+                shortDisplayName(node),
+                nodeKindName(node),
+                kj::heapString(sourceInfo->getDocComment())}));
+        addReference(referenceMap, node.getId(), filePath, range);
+        addDocumentSymbol(
+            documentSymbolMap,
+            filePath,
+            DocumentSymbol{
+                shortDisplayName(node),
+                nodeKindName(node),
+                documentSymbolKind(node),
+                range,
+                range});
+        addMemberDocumentSymbols(
+            node, *sourceInfo, filePath, documentSymbolMap, positionCalculator);
       }
     }
     // KJ_LOG(INFO, "positionToNodeIdMap:");

--- a/src/symbol_resolver.h
+++ b/src/symbol_resolver.h
@@ -16,6 +16,11 @@ public:
                      kj::HashMap<kj::String, kj::HashMap<Range, uint64_t>>
                          &positionToNodeIdMap,
                      kj::HashMap<uint64_t, kj::Own<Location>> &nodeLocationMap,
+                     kj::HashMap<uint64_t, kj::Own<SymbolMetadata>>
+                         &nodeMetadataMap,
+                     kj::HashMap<uint64_t, kj::Vector<Location>> &referenceMap,
+                     kj::HashMap<kj::String, kj::Vector<DocumentSymbol>>
+                         &documentSymbolMap,
                      const kj::Vector<kj::String> &importPaths,
                      const kj::StringPtr &workspacePath);
 };

--- a/tests/initialize_config_test.cpp
+++ b/tests/initialize_config_test.cpp
@@ -140,6 +140,29 @@ capnp::JsonValue::Reader getObjectField(
   KJ_FAIL_REQUIRE("missing field", fieldName);
 }
 
+bool arrayHasObjectWithStringField(
+    const capnp::JsonValue::Reader &value,
+    kj::StringPtr fieldName,
+    kj::StringPtr expected) {
+  if (!value.isArray()) {
+    return false;
+  }
+
+  for (auto item : value.getArray()) {
+    if (!item.isObject()) {
+      continue;
+    }
+    for (auto field : item.getObject()) {
+      if (field.getName() == fieldName && field.getValue().isString() &&
+          field.getValue().getString() == expected) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
 } // namespace
 
 int main() {
@@ -176,6 +199,15 @@ int main() {
     require(
         !hasObjectField(capabilities, "completionProvider"),
         "initialize should not advertise completion without a completion handler");
+    require(
+        hasObjectField(capabilities, "hoverProvider"),
+        "initialize should advertise hover support");
+    require(
+        hasObjectField(capabilities, "referencesProvider"),
+        "initialize should advertise references support");
+    require(
+        hasObjectField(capabilities, "documentSymbolProvider"),
+        "initialize should advertise document symbol support");
   }
 
   {
@@ -333,6 +365,64 @@ struct Person {
         captured.output.find("Constant names must be qualified") ==
             std::string::npos,
         "fixed schema should not republish the previous diagnostic");
+
+    captured.output.clear();
+    handler
+        .handleMessage(lspMessage(kj::str(
+            R"({"jsonrpc":"2.0","id":7,"method":"textDocument/documentSymbol","params":{"textDocument":{"uri":"file://)",
+            schemaPathString.c_str(),
+            R"("}}})")))
+        .wait(io.waitScope);
+    capnp::MallocMessageBuilder documentSymbolResponse;
+    decodeJson(
+        responseJson(
+            kj::StringPtr(captured.output.data(), captured.output.size())),
+        documentSymbolResponse);
+    auto documentSymbolRoot =
+        documentSymbolResponse.getRoot<capnp::JsonValue>().asReader();
+    auto documentSymbolResult = getObjectField(documentSymbolRoot, "result");
+    require(
+        arrayHasObjectWithStringField(documentSymbolResult, "name", "Person"),
+        "documentSymbol should return compiled document symbols as an array result");
+
+    captured.output.clear();
+    handler
+        .handleMessage(lspMessage(kj::str(
+            R"({"jsonrpc":"2.0","id":8,"method":"textDocument/hover","params":{"textDocument":{"uri":"file://)",
+            schemaPathString.c_str(),
+            R"("},"position":{"line":1,"character":8}}})")))
+        .wait(io.waitScope);
+    capnp::MallocMessageBuilder hoverResponse;
+    decodeJson(
+        responseJson(
+            kj::StringPtr(captured.output.data(), captured.output.size())),
+        hoverResponse);
+    auto hoverRoot = hoverResponse.getRoot<capnp::JsonValue>().asReader();
+    auto hoverResult = getObjectField(hoverRoot, "result");
+    auto hoverContents = getObjectField(hoverResult, "contents");
+    auto hoverValue = getObjectField(hoverContents, "value");
+    require(
+        std::string(hoverValue.getString().cStr()).find("const defaultName") !=
+            std::string::npos,
+        "hover should return symbol metadata");
+
+    captured.output.clear();
+    handler
+        .handleMessage(lspMessage(kj::str(
+            R"({"jsonrpc":"2.0","id":9,"method":"textDocument/references","params":{"textDocument":{"uri":"file://)",
+            schemaPathString.c_str(),
+            R"("},"position":{"line":1,"character":8},"context":{"includeDeclaration":true}}})")))
+        .wait(io.waitScope);
+    capnp::MallocMessageBuilder referencesResponse;
+    decodeJson(
+        responseJson(
+            kj::StringPtr(captured.output.data(), captured.output.size())),
+        referencesResponse);
+    auto referencesRoot = referencesResponse.getRoot<capnp::JsonValue>().asReader();
+    auto referencesResult = getObjectField(referencesRoot, "result");
+    require(
+        referencesResult.isArray() && referencesResult.getArray().size() > 0,
+        "references should return locations as an array result");
   }
 
   {

--- a/tests/linked_compiler_test.cpp
+++ b/tests/linked_compiler_test.cpp
@@ -54,6 +54,18 @@ void requireDiagnosticContaining(
   KJ_FAIL_REQUIRE("expected diagnostic was not found", message);
 }
 
+bool hasDocumentSymbol(
+    const kj::Vector<capnp_ls::DocumentSymbol> &symbols,
+    kj::StringPtr name,
+    uint32_t kind) {
+  for (const auto &symbol : symbols) {
+    if (symbol.name == name && symbol.kind == kind) {
+      return true;
+    }
+  }
+  return false;
+}
+
 } // namespace
 
 int main() {
@@ -136,9 +148,13 @@ int main() {
   kj::HashMap<kj::String, kj::HashMap<capnp_ls::Range, uint64_t>>
       positionToNodeIdMap;
   kj::HashMap<uint64_t, kj::Own<capnp_ls::Location>> nodeLocationMap;
+  kj::HashMap<uint64_t, kj::Own<capnp_ls::SymbolMetadata>> nodeMetadataMap;
+  kj::HashMap<uint64_t, kj::Vector<capnp_ls::Location>> referenceMap;
+  kj::HashMap<kj::String, kj::Vector<capnp_ls::DocumentSymbol>>
+      documentSymbolMap;
   auto resolveResult = capnp_ls::SymbolResolver::resolve(
-      request, positionToNodeIdMap, nodeLocationMap, importPaths,
-      CAPNP_LS_TEST_FIXTURE_DIR);
+      request, positionToNodeIdMap, nodeLocationMap, nodeMetadataMap,
+      referenceMap, documentSymbolMap, importPaths, CAPNP_LS_TEST_FIXTURE_DIR);
   require(resolveResult == 0, "symbol resolver should resolve valid fixture");
 
   auto companyPath = fixturePath("schemas/company.capnp");
@@ -150,6 +166,23 @@ int main() {
   require(location->uri == companyPath, "definition should resolve in company.capnp");
   require(location->range.start.line == 18, "definition should start at line 18");
   require(location->range.start.character == 3, "definition should start at character 3");
+  auto &employeeMetadata = KJ_ASSERT_NONNULL(nodeMetadataMap.find(employeeId));
+  require(employeeMetadata->name == "Employee", "hover metadata should use short symbol name");
+  require(employeeMetadata->detail == "struct", "hover metadata should include symbol kind");
+  auto &employeeReferences = KJ_ASSERT_NONNULL(referenceMap.find(employeeId));
+  require(
+      employeeReferences.size() >= 4,
+      "references should include declaration and type usages");
+  auto &companySymbols = KJ_ASSERT_NONNULL(documentSymbolMap.find(companyPath));
+  require(
+      hasDocumentSymbol(companySymbols, "EmployeeManagement", 11),
+      "document symbols should include interfaces");
+  require(
+      hasDocumentSymbol(companySymbols, "addEmployee", 6),
+      "document symbols should include methods");
+  require(
+      hasDocumentSymbol(companySymbols, "Employee", 23),
+      "document symbols should include nested structs");
 
   auto qualifiedImportId = resolveAt(rangeMap, 21, 22);
   auto &qualifiedImportLocation =
@@ -171,6 +204,35 @@ int main() {
       inlineImportLocation->range.start.line == 8,
       "inline imported definition should start at enum line");
 
+  // Resolving the same request again simulates a recompile; it must not
+  // duplicate document symbols or references, including for imported files.
+  auto companySymbolCount = companySymbols.size();
+  auto commonSymbolCount =
+      KJ_ASSERT_NONNULL(documentSymbolMap.find(commonPath)).size();
+  auto employeeReferenceCount = employeeReferences.size();
+  auto qualifiedImportReferenceCount =
+      KJ_ASSERT_NONNULL(referenceMap.find(qualifiedImportId)).size();
+  resolveResult = capnp_ls::SymbolResolver::resolve(
+      request, positionToNodeIdMap, nodeLocationMap, nodeMetadataMap,
+      referenceMap, documentSymbolMap, importPaths, CAPNP_LS_TEST_FIXTURE_DIR);
+  require(resolveResult == 0, "symbol resolver should resolve fixture again");
+  require(
+      KJ_ASSERT_NONNULL(documentSymbolMap.find(companyPath)).size() ==
+          companySymbolCount,
+      "recompile should not duplicate requested file document symbols");
+  require(
+      KJ_ASSERT_NONNULL(documentSymbolMap.find(commonPath)).size() ==
+          commonSymbolCount,
+      "recompile should not duplicate imported file document symbols");
+  require(
+      KJ_ASSERT_NONNULL(referenceMap.find(employeeId)).size() ==
+          employeeReferenceCount,
+      "recompile should not duplicate requested file references");
+  require(
+      KJ_ASSERT_NONNULL(referenceMap.find(qualifiedImportId)).size() ==
+          qualifiedImportReferenceCount,
+      "recompile should not duplicate imported file references");
+
   kj::Vector<kj::String> noImportPaths;
   diagnostics.clear();
   auto standardImportResult = capnp_ls::LinkedCompiler::compile(
@@ -191,8 +253,12 @@ int main() {
       standardImportRequestMessage->getRoot<capnp::schema::CodeGeneratorRequest>();
   positionToNodeIdMap.clear();
   nodeLocationMap.clear();
+  nodeMetadataMap.clear();
+  referenceMap.clear();
+  documentSymbolMap.clear();
   resolveResult = capnp_ls::SymbolResolver::resolve(
-      standardImportRequest, positionToNodeIdMap, nodeLocationMap, noImportPaths,
+      standardImportRequest, positionToNodeIdMap, nodeLocationMap,
+      nodeMetadataMap, referenceMap, documentSymbolMap, noImportPaths,
       CAPNP_LS_TEST_FIXTURE_DIR);
   require(
       resolveResult == 0,


### PR DESCRIPTION
## Summary
- add LSP support for hover, references, and document symbols
- cache symbol metadata, declaration locations, and reference locations from Cap'n Proto compiler source info
- add server and VS Code client coverage for the new language features

## Tests
- just test
- pnpm --dir samples compile
- pnpm --dir samples test (previously passed; skipped final rerun to avoid VS Code download)
- git diff --check