### PR TITLE
Add Cap'n Proto completion support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,8 @@ add_executable(${exe_name}
     src/symbol_index.cpp
     src/diagnostic_publisher.cpp
     src/workspace_state.cpp
+    src/ordinal_completion.cpp
+    src/keyword_completion.cpp
 )
 
 if(NOT EXISTS "${CAPNP_SOURCE_DIR}/src/capnp/compiler/compiler.h")
@@ -111,6 +113,32 @@ if(CAPNP_LS_BUILD_TESTS)
         ${CMAKE_CURRENT_SOURCE_DIR}/src
     )
     add_test(NAME utils COMMAND capnp-ls-utils-test)
+    add_executable(capnp-ls-ordinal-completion-test
+        tests/ordinal_completion_test.cpp
+        src/ordinal_completion.cpp
+        src/lsp_types.cpp
+        src/utils.cpp
+    )
+    target_link_libraries(capnp-ls-ordinal-completion-test PRIVATE
+        kj
+    )
+    target_include_directories(capnp-ls-ordinal-completion-test PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src
+    )
+    add_test(NAME ordinal-completion COMMAND capnp-ls-ordinal-completion-test)
+    add_executable(capnp-ls-keyword-completion-test
+        tests/keyword_completion_test.cpp
+        src/keyword_completion.cpp
+        src/lsp_types.cpp
+        src/utils.cpp
+    )
+    target_link_libraries(capnp-ls-keyword-completion-test PRIVATE
+        kj
+    )
+    target_include_directories(capnp-ls-keyword-completion-test PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src
+    )
+    add_test(NAME keyword-completion COMMAND capnp-ls-keyword-completion-test)
     add_executable(capnp-ls-linked-compiler-test
         tests/linked_compiler_test.cpp
         src/project_config.cpp
@@ -134,6 +162,8 @@ if(CAPNP_LS_BUILD_TESTS)
         src/symbol_index.cpp
         src/diagnostic_publisher.cpp
         src/workspace_state.cpp
+        src/ordinal_completion.cpp
+        src/keyword_completion.cpp
     )
     target_sources(capnp-ls-initialize-config-test PRIVATE
         "${CAPNP_SOURCE_DIR}/src/capnp/compiler/module-loader.c++"
@@ -178,4 +208,42 @@ if(CAPNP_LS_BUILD_TESTS)
     )
     add_test(NAME linked-compiler COMMAND capnp-ls-linked-compiler-test)
     add_test(NAME initialize-config COMMAND capnp-ls-initialize-config-test)
+    add_executable(capnp-ls-completion-test
+        tests/completion_test.cpp
+        src/stdout_writer.cpp
+        src/lsp_message_handler.cpp
+        src/json_rpc.cpp
+        src/lsp_json.cpp
+        src/lsp_types.cpp
+        src/project_config.cpp
+        src/utils.cpp
+        src/linked_compiler.cpp
+        src/compilation_manager.cpp
+        src/symbol_resolver.cpp
+        src/symbol_index.cpp
+        src/diagnostic_publisher.cpp
+        src/workspace_state.cpp
+        src/ordinal_completion.cpp
+        src/keyword_completion.cpp
+    )
+    target_sources(capnp-ls-completion-test PRIVATE
+        "${CAPNP_SOURCE_DIR}/src/capnp/compiler/module-loader.c++"
+    )
+    target_include_directories(capnp-ls-completion-test BEFORE PRIVATE
+        ${CAPNP_SOURCE_DIR}/src
+    )
+    target_link_libraries(capnp-ls-completion-test PRIVATE
+        capnp-json
+        capnpc
+        capnp
+        kj-async
+        kj
+    )
+    target_include_directories(capnp-ls-completion-test PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src
+    )
+    target_compile_definitions(capnp-ls-completion-test PRIVATE
+        CAPNP_LS_CAPNP_SOURCE_DIR="${CAPNP_SOURCE_DIR}"
+    )
+    add_test(NAME completion COMMAND capnp-ls-completion-test)
 endif()

--- a/README.md
+++ b/README.md
@@ -200,6 +200,16 @@ initialization options are:
 
 - Enables navigation to the definition of types, enums, and other symbols in Cap'n Proto schema files.
 
+### Completion
+
+- Suggests the next field, method, or enumerant ordinal when typing `@` inside
+  a struct, interface, or enum body, based on the unsaved editor buffer.
+- Members of `union` and `group` blocks are numbered within the enclosing
+  struct's ordinal space, matching the Cap'n Proto schema language.
+- Suggests declaration keywords (`struct`, `interface`, `enum`, `const`,
+  `using`, `annotation`, and `union` where valid) when typing the first word
+  of a statement.
+
 ### File Watching
 
 - Automatically recompiles schemas when files are saved.
@@ -210,7 +220,6 @@ initialization options are:
 
 ## Upcoming Features
 
-- Autocomplete feature that includes ordinals
 - Formatting feature
 
 ## Sample VSCode Extension

--- a/samples/client/testFixture/schemas/company.capnp
+++ b/samples/client/testFixture/schemas/company.capnp
@@ -29,6 +29,7 @@ interface EmployeeManagement {
         street @8 :Text;
         city @9 :Text;
         country @10 :Text;
+        town @11 :Text;
       }
     }
   }

--- a/src/keyword_completion.cpp
+++ b/src/keyword_completion.cpp
@@ -1,0 +1,205 @@
+// Copyright (c) 2024 Atsushi Tomida
+//
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
+
+#include "keyword_completion.h"
+#include "kj_compat.h"
+#include "utils.h"
+#include <kj/vector.h>
+
+namespace capnp_ls {
+
+namespace {
+
+enum class BlockKind { STRUCT, INTERFACE, ENUM, UNION_GROUP, OPAQUE };
+
+// Keywords that may start a declaration at file scope or in an interface
+// body. Struct bodies additionally allow an unnamed "union"; union and group
+// bodies allow only a nested "union"; enum bodies hold only enumerants.
+const kj::StringPtr DECLARATION_KEYWORDS[] = {
+    "struct",
+    "interface",
+    "enum",
+    "const",
+    "using",
+    "annotation"};
+const kj::StringPtr STRUCT_KEYWORDS[] = {
+    "struct",
+    "interface",
+    "enum",
+    "union",
+    "const",
+    "using",
+    "annotation"};
+const kj::StringPtr UNION_GROUP_KEYWORDS[] = {"union"};
+
+template <size_t size>
+kj::ArrayPtr<const kj::StringPtr> keywordList(
+    const kj::StringPtr (&list)[size]) {
+  return kj::arrayPtr(list, size);
+}
+
+bool isDecimalDigit(char c) {
+  return c >= '0' && c <= '9';
+}
+
+bool isIdentifierChar(char c) {
+  return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '_' ||
+      isDecimalDigit(c);
+}
+
+bool isWhitespace(char c) {
+  return c == ' ' || c == '\t' || c == '\r' || c == '\n';
+}
+
+} // namespace
+
+kj::Maybe<KeywordCompletion> computeKeywordCompletion(
+    kj::StringPtr text,
+    uint32_t line,
+    uint32_t character) {
+  size_t cursorOffset = 0;
+  CAPNP_LS_IF_SOME (offset, byteOffsetForPosition(text, line, character)) {
+    cursorOffset = *offset;
+  } else {
+    return CAPNP_LS_NONE;
+  }
+
+  enum class LexState { CODE, COMMENT, STRING };
+
+  kj::Vector<BlockKind> stack;
+  LexState state = LexState::CODE;
+  kj::Maybe<BlockKind> pending;
+  size_t tokenCount = 0;
+  size_t firstTokenStart = 0;
+
+  size_t i = 0;
+  while (i < cursorOffset) {
+    char c = text[i];
+    switch (state) {
+    case LexState::COMMENT:
+      if (c == '\n') {
+        state = LexState::CODE;
+      }
+      ++i;
+      break;
+    case LexState::STRING:
+      if (c == '\\') {
+        i += 2;
+      } else {
+        if (c == '"' || c == '\n') {
+          state = LexState::CODE;
+        }
+        ++i;
+      }
+      break;
+    case LexState::CODE:
+      if (c == '#') {
+        state = LexState::COMMENT;
+        ++i;
+      } else if (c == '"') {
+        if (tokenCount == 0) {
+          firstTokenStart = i;
+        }
+        ++tokenCount;
+        state = LexState::STRING;
+        ++i;
+      } else if (c == ';') {
+        tokenCount = 0;
+        pending = CAPNP_LS_NONE;
+        ++i;
+      } else if (c == '{') {
+        BlockKind kind = BlockKind::OPAQUE;
+        CAPNP_LS_IF_SOME (pendingKind, pending) {
+          kind = *pendingKind;
+        }
+        stack.add(kind);
+        pending = CAPNP_LS_NONE;
+        tokenCount = 0;
+        ++i;
+      } else if (c == '}') {
+        if (stack.size() > 0) {
+          stack.removeLast();
+        }
+        pending = CAPNP_LS_NONE;
+        tokenCount = 0;
+        ++i;
+      } else if (isIdentifierChar(c)) {
+        if (tokenCount == 0) {
+          firstTokenStart = i;
+        }
+        ++tokenCount;
+        size_t end = i + 1;
+        while (end < text.size() && isIdentifierChar(text[end])) {
+          ++end;
+        }
+        auto word = text.slice(i, end);
+        if (word == kj::StringPtr("struct")) {
+          pending = BlockKind::STRUCT;
+        } else if (word == kj::StringPtr("interface")) {
+          pending = BlockKind::INTERFACE;
+        } else if (word == kj::StringPtr("enum")) {
+          pending = BlockKind::ENUM;
+        } else if (
+            word == kj::StringPtr("union") || word == kj::StringPtr("group")) {
+          pending = BlockKind::UNION_GROUP;
+        }
+        i = end;
+      } else if (isWhitespace(c)) {
+        ++i;
+      } else {
+        if (tokenCount == 0) {
+          firstTokenStart = i;
+        }
+        ++tokenCount;
+        ++i;
+      }
+      break;
+    }
+  }
+
+  if (state != LexState::CODE) {
+    return CAPNP_LS_NONE;
+  }
+
+  size_t prefixStart = cursorOffset;
+  while (prefixStart > 0 && isIdentifierChar(text[prefixStart - 1])) {
+    --prefixStart;
+  }
+  if (prefixStart > 0 && text[prefixStart - 1] == '@') {
+    return CAPNP_LS_NONE; // an ordinal position
+  }
+  bool atStatementStart = prefixStart == cursorOffset
+      ? tokenCount == 0
+      : tokenCount == 1 && firstTokenStart == prefixStart;
+  if (!atStatementStart) {
+    return CAPNP_LS_NONE;
+  }
+
+  kj::ArrayPtr<const kj::StringPtr> keywords;
+  if (stack.size() == 0) {
+    keywords = keywordList(DECLARATION_KEYWORDS);
+  } else {
+    switch (stack[stack.size() - 1]) {
+    case BlockKind::STRUCT:
+      keywords = keywordList(STRUCT_KEYWORDS);
+      break;
+    case BlockKind::INTERFACE:
+      keywords = keywordList(DECLARATION_KEYWORDS);
+      break;
+    case BlockKind::UNION_GROUP:
+      keywords = keywordList(UNION_GROUP_KEYWORDS);
+      break;
+    case BlockKind::ENUM:
+    case BlockKind::OPAQUE:
+      return CAPNP_LS_NONE;
+    }
+  }
+
+  uint32_t prefixLength = static_cast<uint32_t>(cursorOffset - prefixStart);
+  Range replaceRange{{line, character - prefixLength}, {line, character}};
+  return KeywordCompletion{keywords, replaceRange};
+}
+
+} // namespace capnp_ls

--- a/src/keyword_completion.h
+++ b/src/keyword_completion.h
@@ -1,0 +1,34 @@
+// Copyright (c) 2024 Atsushi Tomida
+//
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
+
+#pragma once
+
+#include "lsp_types.h"
+#include <kj/common.h>
+#include <kj/string.h>
+
+namespace capnp_ls {
+
+// Positions follow the internal 1-based convention (see lsp_json.cpp);
+// character counts UTF-16 code units. keywords point at static storage.
+// replaceRange covers the identifier prefix already typed (an empty range at
+// the cursor when none).
+struct KeywordCompletion {
+  kj::ArrayPtr<const kj::StringPtr> keywords;
+  Range replaceRange;
+};
+
+// Suggests declaration keywords when the cursor is typing the first word of a
+// statement. The candidate set depends on the enclosing block: file scope and
+// interface bodies offer declaration keywords, struct bodies additionally
+// offer "union", union/group bodies offer only "union", and enum bodies offer
+// nothing. Returns none mid-statement, inside comments or strings, and right
+// after '@' (an ordinal position).
+kj::Maybe<KeywordCompletion> computeKeywordCompletion(
+    kj::StringPtr text,
+    uint32_t line,
+    uint32_t character);
+
+} // namespace capnp_ls

--- a/src/lsp_message_handler.cpp
+++ b/src/lsp_message_handler.cpp
@@ -5,9 +5,11 @@
 
 #include "lsp_message_handler.h"
 #include "json_rpc.h"
+#include "keyword_completion.h"
 #include "kj_compat.h"
 #include "lsp_json.h"
 #include "lsp_types.h"
+#include "ordinal_completion.h"
 #include "workspace_state.h"
 #include <capnp/compat/json.h>
 #include <capnp/message.h>
@@ -170,17 +172,21 @@ kj::Promise<void> LspMessageHandler::dispatch(LspMethod method, const capnp::Jso
     return handleDocumentSymbol(params, response);
   case LspMethod::DID_OPEN:
     return handleDidOpenTextDocument(params);
+  case LspMethod::DID_CHANGE:
+    return handleDidChangeTextDocument(params);
+  case LspMethod::DID_CLOSE:
+    return handleDidCloseTextDocument(params);
   case LspMethod::DID_SAVE:
     return handleDidSave(params);
   case LspMethod::DID_CHANGE_WATCHED_FILES:
     return handleDidChangeWatchedFiles(params);
+  case LspMethod::COMPLETION:
+    return handleCompletion(params, response);
   case LspMethod::FORMATTING:
     return handleFormatting(params, response);
   case LspMethod::INITIALIZED:
   case LspMethod::SET_TRACE:
   case LspMethod::CANCEL_REQUEST:
-  case LspMethod::DID_CHANGE:
-  case LspMethod::DID_CLOSE:
     break;
   }
   return kj::READY_NOW;
@@ -510,7 +516,7 @@ kj::Promise<void> LspMessageHandler::handleInitialize(
   auto capsField = resultValue[0];
   capsField.setName("capabilities");
 
-  auto capabilities = capsField.getValue().initObject(5);
+  auto capabilities = capsField.getValue().initObject(6);
 
   // Set text document sync capability
   auto syncField = capabilities[0];
@@ -546,6 +552,13 @@ kj::Promise<void> LspMessageHandler::handleInitialize(
   documentSymbolField.setName("documentSymbolProvider");
   documentSymbolField.getValue().setBoolean(true);
 
+  auto completionField = capabilities[5];
+  completionField.setName("completionProvider");
+  auto completionProvider = completionField.getValue().initObject(1);
+  completionProvider[0].setName("triggerCharacters");
+  auto triggerCharacters = completionProvider[0].getValue().initArray(1);
+  triggerCharacters[0].setString("@");
+
   return kj::READY_NOW;
 }
 
@@ -556,6 +569,41 @@ kj::Promise<void> LspMessageHandler::handleDidOpenTextDocument(
   try {
     auto paramsObj = params.getObject();
     kj::String uri;
+    kj::String text;
+
+    for (auto field : paramsObj) {
+      if (field.getName() == "textDocument") {
+        auto textDocument = field.getValue().getObject();
+        for (auto docField : textDocument) {
+          if (docField.getName() == "uri") {
+            uri = kj::heapString(docField.getValue().getString());
+          } else if (docField.getName() == "text") {
+            text = kj::heapString(docField.getValue().getString());
+          }
+        }
+      }
+    }
+    if (uri.size() > 0) {
+      openDocuments.upsert(uriToPath(uri), kj::mv(text));
+    }
+    return compileCapnpFile(uri);
+  } catch (kj::Exception &e) {
+    KJ_LOG(
+        ERROR,
+        "Error processing didOpenTextDocument notification",
+        e.getDescription());
+  }
+  return kj::READY_NOW;
+}
+
+kj::Promise<void> LspMessageHandler::handleDidChangeTextDocument(
+    const capnp::JsonValue::Reader &params) {
+  KJ_LOG(INFO, "Handling didChangeTextDocument notification");
+
+  try {
+    auto paramsObj = params.getObject();
+    kj::String uri;
+    kj::Maybe<kj::String> fullText;
 
     for (auto field : paramsObj) {
       if (field.getName() == "textDocument") {
@@ -565,15 +613,115 @@ kj::Promise<void> LspMessageHandler::handleDidOpenTextDocument(
             uri = kj::heapString(docField.getValue().getString());
           }
         }
+      } else if (field.getName() == "contentChanges") {
+        for (auto change : field.getValue().getArray()) {
+          // The server advertises full document sync (change = 1), so each
+          // change carries the complete text; a range would mean an
+          // incremental change we must not apply as a replacement.
+          bool hasRange = false;
+          kj::Maybe<kj::String> changeText;
+          for (auto changeField : change.getObject()) {
+            if (changeField.getName() == "range") {
+              hasRange = true;
+            } else if (changeField.getName() == "text") {
+              changeText = kj::heapString(changeField.getValue().getString());
+            }
+          }
+          if (!hasRange) {
+            fullText = kj::mv(changeText);
+          }
+        }
       }
     }
-    return compileCapnpFile(uri);
+    if (uri.size() > 0) {
+      CAPNP_LS_IF_SOME (text, fullText) {
+        openDocuments.upsert(uriToPath(uri), kj::mv(*text));
+      }
+    }
   } catch (kj::Exception &e) {
     KJ_LOG(
         ERROR,
-        "Error processing didOpenTextDocument notification",
+        "Error processing didChangeTextDocument notification",
         e.getDescription());
   }
+  return kj::READY_NOW;
+}
+
+kj::Promise<void> LspMessageHandler::handleDidCloseTextDocument(
+    const capnp::JsonValue::Reader &params) {
+  KJ_LOG(INFO, "Handling didCloseTextDocument notification");
+
+  try {
+    auto path = parseTextDocumentPath(params);
+    openDocuments.erase(path);
+  } catch (kj::Exception &e) {
+    KJ_LOG(
+        ERROR,
+        "Error processing didCloseTextDocument notification",
+        e.getDescription());
+  }
+  return kj::READY_NOW;
+}
+
+kj::Promise<void> LspMessageHandler::handleCompletion(
+    const capnp::JsonValue::Reader &params,
+    capnp::MallocMessageBuilder &completionResponseBuilder) {
+  KJ_LOG(INFO, "Handling completion request");
+
+  auto root = completionResponseBuilder.initRoot<capnp::JsonValue>();
+  auto resultObj = root.initObject(1);
+  auto resultField = resultObj[0];
+  resultField.setName(LSP_RESULT);
+
+  try {
+    auto position = parseTextDocumentPosition(params);
+    CAPNP_LS_IF_SOME (text, openDocuments.find(position.path)) {
+      CAPNP_LS_IF_SOME (
+          completion,
+          computeOrdinalCompletion(*text, position.line, position.character)) {
+        auto label = kj::str(completion->nextOrdinal);
+        auto array = resultField.getValue().initArray(1);
+        auto item = array[0].initObject(4);
+        item[0].setName("label");
+        item[0].getValue().setString(label);
+        item[1].setName("kind");
+        item[1].getValue().setNumber(12); // CompletionItemKind.Value
+        item[2].setName("preselect");
+        item[2].getValue().setBoolean(true);
+        item[3].setName("textEdit");
+        auto textEdit = item[3].getValue().initObject(2);
+        textEdit[0].setName("range");
+        setRange(textEdit[0].getValue(), completion->replaceRange);
+        textEdit[1].setName("newText");
+        textEdit[1].getValue().setString(label);
+        return kj::READY_NOW;
+      }
+      CAPNP_LS_IF_SOME (
+          completion,
+          computeKeywordCompletion(*text, position.line, position.character)) {
+        auto array = resultField.getValue().initArray(completion->keywords.size());
+        for (size_t i = 0; i < completion->keywords.size(); ++i) {
+          auto keyword = completion->keywords[i];
+          auto item = array[i].initObject(3);
+          item[0].setName("label");
+          item[0].getValue().setString(keyword);
+          item[1].setName("kind");
+          item[1].getValue().setNumber(14); // CompletionItemKind.Keyword
+          item[2].setName("textEdit");
+          auto textEdit = item[2].getValue().initObject(2);
+          textEdit[0].setName("range");
+          setRange(textEdit[0].getValue(), completion->replaceRange);
+          textEdit[1].setName("newText");
+          textEdit[1].getValue().setString(keyword);
+        }
+        return kj::READY_NOW;
+      }
+    }
+  } catch (kj::Exception &e) {
+    KJ_LOG(ERROR, "Error processing completion request", e.getDescription());
+  }
+
+  resultField.getValue().initArray(0);
   return kj::READY_NOW;
 }
 

--- a/src/lsp_message_handler.h
+++ b/src/lsp_message_handler.h
@@ -72,6 +72,13 @@ private:
       capnp::MallocMessageBuilder &initializeResponseBuilder);
   kj::Promise<void>
   handleDidOpenTextDocument(const capnp::JsonValue::Reader &params);
+  kj::Promise<void>
+  handleDidChangeTextDocument(const capnp::JsonValue::Reader &params);
+  kj::Promise<void>
+  handleDidCloseTextDocument(const capnp::JsonValue::Reader &params);
+  kj::Promise<void> handleCompletion(
+      const capnp::JsonValue::Reader &params,
+      capnp::MallocMessageBuilder &completionResponseBuilder);
   kj::Promise<void> handleFormatting(
       const capnp::JsonValue::Reader &params,
       capnp::MallocMessageBuilder &formattingResponseBuilder);
@@ -81,6 +88,9 @@ private:
 
   SymbolIndex index;
   WorkspaceState workspace;
+  // Editor buffers keyed by file path; the source of truth for features that
+  // must work on unsaved text (completion).
+  kj::HashMap<kj::String, kj::String> openDocuments;
   ServerContext &context;
   kj::Own<CompilationManager> compilationManager;
   StdoutWriter &stdoutWriter;

--- a/src/lsp_types.h
+++ b/src/lsp_types.h
@@ -40,6 +40,7 @@ constexpr const char LSP_ERROR[] = "error";
   MACRO(DID_SAVE, "textDocument/didSave")                                      \
   MACRO(DID_CHANGE, "textDocument/didChange")                                  \
   MACRO(DID_CLOSE, "textDocument/didClose")                                    \
+  MACRO(COMPLETION, "textDocument/completion")                                 \
   MACRO(INITIALIZED, "initialized")                                            \
   MACRO(SET_TRACE, "$/setTrace")                                               \
   MACRO(CANCEL_REQUEST, "$/cancelRequest")                                     \

--- a/src/ordinal_completion.cpp
+++ b/src/ordinal_completion.cpp
@@ -1,0 +1,228 @@
+// Copyright (c) 2024 Atsushi Tomida
+//
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
+
+#include "ordinal_completion.h"
+#include "kj_compat.h"
+#include "utils.h"
+#include <kj/vector.h>
+
+namespace capnp_ls {
+
+namespace {
+
+// struct/interface/enum bodies own an ordinal numbering space; union and
+// group members number within the enclosing struct's space; braces not
+// preceded by one of those keywords are treated as opaque.
+enum class BlockKind { OWNS_SPACE, SHARES_PARENT, OPAQUE };
+
+struct Block {
+  BlockKind kind;
+  // Index (into the open-block stack) of the block owning this block's
+  // ordinal space: itself for OWNS_SPACE/OPAQUE, an ancestor for
+  // SHARES_PARENT.
+  size_t spaceIndex;
+  kj::Maybe<uint32_t> maxOrdinal;
+};
+
+bool isDecimalDigit(char c) {
+  return c >= '0' && c <= '9';
+}
+
+bool isHexDigit(char c) {
+  return isDecimalDigit(c) || (c >= 'a' && c <= 'f') ||
+      (c >= 'A' && c <= 'F');
+}
+
+bool isIdentifierStart(char c) {
+  return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '_';
+}
+
+bool isIdentifierChar(char c) {
+  return isIdentifierStart(c) || isDecimalDigit(c);
+}
+
+} // namespace
+
+kj::Maybe<OrdinalCompletion> computeOrdinalCompletion(
+    kj::StringPtr text,
+    uint32_t line,
+    uint32_t character) {
+  size_t cursorOffset = 0;
+  CAPNP_LS_IF_SOME (offset, byteOffsetForPosition(text, line, character)) {
+    cursorOffset = *offset;
+  } else {
+    return CAPNP_LS_NONE;
+  }
+
+  // Only complete right after '@' plus any digits already typed.
+  size_t digitsStart = cursorOffset;
+  while (digitsStart > 0 && isDecimalDigit(text[digitsStart - 1])) {
+    --digitsStart;
+  }
+  if (digitsStart == 0 || text[digitsStart - 1] != '@') {
+    return CAPNP_LS_NONE;
+  }
+  uint32_t typedDigits = static_cast<uint32_t>(cursorOffset - digitsStart);
+
+  auto makeCompletion = [&](kj::Maybe<uint32_t> maxOrdinal) {
+    uint32_t next = 0;
+    CAPNP_LS_IF_SOME (value, maxOrdinal) {
+      next = *value + 1;
+    }
+    Range replaceRange{
+        {line, character - typedDigits},
+        {line, character}};
+    return OrdinalCompletion{next, replaceRange};
+  };
+
+  enum class LexState { CODE, COMMENT, STRING };
+  enum class Pending { NONE, OWNS_SPACE, SHARES_PARENT };
+
+  kj::Vector<Block> stack;
+  LexState state = LexState::CODE;
+  Pending pending = Pending::NONE;
+  bool cursorSeen = false;
+  kj::Maybe<size_t> cursorSpace;
+
+  auto snapshotCursor = [&]() {
+    cursorSeen = true;
+    if (state != LexState::CODE || stack.size() == 0) {
+      return;
+    }
+    size_t space = stack[stack.size() - 1].spaceIndex;
+    if (stack[space].kind == BlockKind::OWNS_SPACE) {
+      cursorSpace = space;
+    }
+  };
+
+  size_t i = 0;
+  while (i < text.size()) {
+    if (!cursorSeen && i >= cursorOffset) {
+      snapshotCursor();
+    }
+    char c = text[i];
+    switch (state) {
+    case LexState::COMMENT:
+      if (c == '\n') {
+        state = LexState::CODE;
+      }
+      ++i;
+      break;
+    case LexState::STRING:
+      if (c == '\\') {
+        i += 2;
+      } else {
+        if (c == '"' || c == '\n') {
+          state = LexState::CODE;
+        }
+        ++i;
+      }
+      break;
+    case LexState::CODE:
+      if (c == '#') {
+        state = LexState::COMMENT;
+        ++i;
+      } else if (c == '"') {
+        state = LexState::STRING;
+        ++i;
+      } else if (c == ';') {
+        pending = Pending::NONE;
+        ++i;
+      } else if (c == '{') {
+        Block block;
+        if (pending == Pending::OWNS_SPACE) {
+          block.kind = BlockKind::OWNS_SPACE;
+          block.spaceIndex = stack.size();
+        } else if (pending == Pending::SHARES_PARENT && stack.size() > 0) {
+          block.kind = BlockKind::SHARES_PARENT;
+          block.spaceIndex = stack[stack.size() - 1].spaceIndex;
+        } else {
+          block.kind = BlockKind::OPAQUE;
+          block.spaceIndex = stack.size();
+        }
+        stack.add(block);
+        pending = Pending::NONE;
+        ++i;
+      } else if (c == '}') {
+        pending = Pending::NONE;
+        if (stack.size() > 0) {
+          size_t closing = stack.size() - 1;
+          CAPNP_LS_IF_SOME (space, cursorSpace) {
+            if (*space == closing) {
+              return makeCompletion(stack[closing].maxOrdinal);
+            }
+          }
+          stack.removeLast();
+        }
+        ++i;
+      } else if (c == '@') {
+        size_t numberStart = i + 1;
+        if (numberStart + 1 < text.size() && text[numberStart] == '0' &&
+            (text[numberStart + 1] == 'x' || text[numberStart + 1] == 'X')) {
+          // 64-bit hex ID (file/type/annotation), not an ordinal.
+          i = numberStart + 2;
+          while (i < text.size() && isHexDigit(text[i])) {
+            ++i;
+          }
+        } else if (
+            numberStart < text.size() && isDecimalDigit(text[numberStart])) {
+          uint32_t value = 0;
+          size_t end = numberStart;
+          while (end < text.size() && isDecimalDigit(text[end])) {
+            if (value < 0xffff) {
+              value = value * 10 + static_cast<uint32_t>(text[end] - '0');
+            }
+            ++end;
+          }
+          // The ordinal under the cursor is the one being completed; it must
+          // not count toward the existing maximum.
+          bool isTokenBeingTyped = cursorOffset > i && cursorOffset <= end;
+          if (!isTokenBeingTyped && stack.size() > 0) {
+            Block &owner = stack[stack[stack.size() - 1].spaceIndex];
+            CAPNP_LS_IF_SOME (current, owner.maxOrdinal) {
+              if (value > *current) {
+                owner.maxOrdinal = value;
+              }
+            } else {
+              owner.maxOrdinal = value;
+            }
+          }
+          i = end;
+        } else {
+          ++i;
+        }
+      } else if (isIdentifierStart(c)) {
+        size_t end = i + 1;
+        while (end < text.size() && isIdentifierChar(text[end])) {
+          ++end;
+        }
+        auto word = text.slice(i, end);
+        if (word == kj::StringPtr("struct") ||
+            word == kj::StringPtr("interface") ||
+            word == kj::StringPtr("enum")) {
+          pending = Pending::OWNS_SPACE;
+        } else if (
+            word == kj::StringPtr("union") || word == kj::StringPtr("group")) {
+          pending = Pending::SHARES_PARENT;
+        }
+        i = end;
+      } else {
+        ++i;
+      }
+      break;
+    }
+  }
+
+  if (!cursorSeen) {
+    snapshotCursor();
+  }
+  CAPNP_LS_IF_SOME (space, cursorSpace) {
+    // The owning block never closed (file still being edited).
+    return makeCompletion(stack[*space].maxOrdinal);
+  }
+  return CAPNP_LS_NONE;
+}
+
+} // namespace capnp_ls

--- a/src/ordinal_completion.h
+++ b/src/ordinal_completion.h
@@ -1,0 +1,32 @@
+// Copyright (c) 2024 Atsushi Tomida
+//
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
+
+#pragma once
+
+#include "lsp_types.h"
+#include <kj/common.h>
+#include <kj/string.h>
+
+namespace capnp_ls {
+
+// Positions follow the internal 1-based convention (see lsp_json.cpp);
+// character counts UTF-16 code units. replaceRange covers the digits already
+// typed after '@' (an empty range at the cursor when none).
+struct OrdinalCompletion {
+  uint32_t nextOrdinal;
+  Range replaceRange;
+};
+
+// Suggests the next field/method/enumerant ordinal when the cursor sits right
+// after '@' (optionally followed by typed digits). Ordinal spaces: struct,
+// interface and enum bodies own one each; union and group members share the
+// enclosing struct's space. Returns none when the cursor is not in an ordinal
+// position (no '@' before it, top level, inside a comment or string).
+kj::Maybe<OrdinalCompletion> computeOrdinalCompletion(
+    kj::StringPtr text,
+    uint32_t line,
+    uint32_t character);
+
+} // namespace capnp_ls

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -8,6 +8,7 @@
 
 #include <cstdint>
 
+#include "kj_compat.h"
 #include "utils.h"
 
 namespace capnp_ls {
@@ -93,6 +94,40 @@ kj::String pathToUri(const kj::StringPtr path) {
   }
 
   return kj::heapString(encoded.begin(), encoded.size());
+}
+
+kj::Maybe<size_t> byteOffsetForPosition(
+    kj::StringPtr text,
+    uint32_t line,
+    uint32_t character) {
+  size_t offset = 0;
+  for (uint32_t currentLine = 1; currentLine < line; ++currentLine) {
+    while (offset < text.size() && text[offset] != '\n') {
+      ++offset;
+    }
+    if (offset >= text.size()) {
+      return CAPNP_LS_NONE;
+    }
+    ++offset;
+  }
+  uint32_t units = 1;
+  while (offset < text.size() && text[offset] != '\n' && units < character) {
+    unsigned char head = static_cast<unsigned char>(text[offset]);
+    if ((head & 0xf8) == 0xf0) {
+      offset += 4;
+      units += 2; // outside the BMP: a surrogate pair on the wire
+    } else if ((head & 0xf0) == 0xe0) {
+      offset += 3;
+      units += 1;
+    } else if ((head & 0xe0) == 0xc0) {
+      offset += 2;
+      units += 1;
+    } else {
+      offset += 1;
+      units += 1;
+    }
+  }
+  return offset < text.size() ? offset : text.size();
 }
 
 } // namespace capnp_ls

--- a/src/utils.h
+++ b/src/utils.h
@@ -5,9 +5,19 @@
 
 #pragma once
 
+#include <cstddef>
+#include <cstdint>
+#include <kj/common.h>
 #include <kj/string.h>
 
 namespace capnp_ls {
 kj::String uriToPath(const kj::StringPtr uri);
 kj::String pathToUri(const kj::StringPtr path);
+
+// Byte offset of an internal 1-based position. character counts UTF-16 code
+// units (LSP wire convention) and is clamped to the end of the line.
+kj::Maybe<size_t> byteOffsetForPosition(
+    kj::StringPtr text,
+    uint32_t line,
+    uint32_t character);
 }

--- a/tests/completion_test.cpp
+++ b/tests/completion_test.cpp
@@ -1,0 +1,314 @@
+// Copyright (c) 2024 Atsushi Tomida
+//
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
+
+#include "lsp_message_handler.h"
+#include "stdout_writer.h"
+#include <capnp/common.h>
+#include <capnp/compat/json.h>
+#include <capnp/message.h>
+#include <filesystem>
+#include <fstream>
+#include <kj/async-io.h>
+#include <kj/debug.h>
+#include <string>
+#include <unistd.h>
+
+namespace {
+
+class CapturingOutputStream final : public kj::AsyncOutputStream {
+public:
+#if CAPNP_VERSION_MAJOR >= 2
+  kj::Promise<void> write(kj::ArrayPtr<const kj::byte> buffer) override {
+    output.append(reinterpret_cast<const char *>(buffer.begin()), buffer.size());
+    return kj::READY_NOW;
+  }
+#else
+  kj::Promise<void> write(const void *buffer, size_t size) override {
+    output.append(reinterpret_cast<const char *>(buffer), size);
+    return kj::READY_NOW;
+  }
+#endif
+
+  kj::Promise<void>
+  write(kj::ArrayPtr<const kj::ArrayPtr<const kj::byte>> pieces) override {
+    for (auto piece : pieces) {
+      output.append(reinterpret_cast<const char *>(piece.begin()), piece.size());
+    }
+    return kj::READY_NOW;
+  }
+
+  kj::Promise<void> whenWriteDisconnected() override {
+    return kj::NEVER_DONE;
+  }
+
+  std::string output;
+};
+
+void require(bool condition, kj::StringPtr message) {
+  if (!condition) {
+    KJ_FAIL_REQUIRE(message);
+  }
+}
+
+std::filesystem::path makeTempWorkspace() {
+  auto path = std::filesystem::temp_directory_path() /
+      kj::str("capnp-ls-completion-test-", getpid()).cStr();
+  std::filesystem::remove_all(path);
+  std::filesystem::create_directories(path);
+  return path;
+}
+
+void writeSchema(const std::filesystem::path &path, kj::StringPtr content) {
+  std::ofstream output(path);
+  output.write(content.begin(), content.size());
+}
+
+void decodeJson(kj::StringPtr json, capnp::MallocMessageBuilder &builder) {
+  capnp::JsonCodec codec;
+  auto root = builder.initRoot<capnp::JsonValue>();
+  codec.decodeRaw(kj::arrayPtr(json.begin(), json.size()), root);
+}
+
+kj::String lspMessage(kj::StringPtr json) {
+  return kj::str("Content-Length: ", json.size(), "\r\n\r\n", json);
+}
+
+kj::StringPtr responseJson(kj::StringPtr message) {
+  kj::StringPtr delimiter = "\r\n\r\n";
+  for (auto i = 0; i + delimiter.size() <= message.size(); ++i) {
+    if (message.slice(i, i + delimiter.size()) == delimiter) {
+      return message.slice(i + delimiter.size());
+    }
+  }
+  KJ_FAIL_REQUIRE("response should include an LSP header");
+}
+
+capnp::JsonValue::Reader getObjectField(
+    const capnp::JsonValue::Reader &value,
+    kj::StringPtr fieldName) {
+  for (auto field : value.getObject()) {
+    if (field.getName() == fieldName) {
+      return field.getValue();
+    }
+  }
+
+  KJ_FAIL_REQUIRE("missing field", fieldName);
+}
+
+} // namespace
+
+int main() {
+  auto io = kj::setupAsyncIo();
+  auto paf = kj::newPromiseAndFulfiller<void>();
+  capnp_ls::ServerContext context(kj::mv(paf.fulfiller));
+
+  auto workspace = makeTempWorkspace();
+  KJ_DEFER(std::filesystem::remove_all(workspace));
+  auto schemaPath = workspace / "person.capnp";
+  auto schemaPathString = schemaPath.string();
+  // The on-disk file stays one edit behind the editor buffer so the test can
+  // tell which one completion reads.
+  writeSchema(
+      schemaPath,
+      R"(@0xdba53d6c0e9fe303;
+struct Person {
+  name @0 :Text;
+  age @1 :UInt32;
+}
+)");
+
+  auto stream = kj::heap<CapturingOutputStream>();
+  auto &captured = *stream;
+  capnp_ls::StdoutWriter writer(kj::mv(stream));
+  capnp_ls::LspMessageHandler handler(context, writer);
+
+  auto workspaceString = workspace.string();
+  handler
+      .handleMessage(lspMessage(kj::str(
+          R"({"jsonrpc":"2.0","id":1,"method":"initialize","params":{"workspaceFolders":[{"uri":"file://)",
+          workspaceString.c_str(),
+          R"("}]}})")))
+      .wait(io.waitScope);
+
+  {
+    capnp::MallocMessageBuilder response;
+    decodeJson(
+        responseJson(
+            kj::StringPtr(captured.output.data(), captured.output.size())),
+        response);
+    auto root = response.getRoot<capnp::JsonValue>().asReader();
+    auto result = getObjectField(root, "result");
+    auto capabilities = getObjectField(result, "capabilities");
+    auto completionProvider = getObjectField(capabilities, "completionProvider");
+    auto triggerCharacters =
+        getObjectField(completionProvider, "triggerCharacters");
+    require(
+        triggerCharacters.isArray() && triggerCharacters.getArray().size() == 1 &&
+            triggerCharacters.getArray()[0].getString() == "@",
+        "initialize should advertise '@' as the completion trigger character");
+  }
+
+  captured.output.clear();
+  handler
+      .handleMessage(lspMessage(kj::str(
+          R"({"jsonrpc":"2.0","method":"textDocument/didOpen","params":{"textDocument":{"uri":"file://)",
+          schemaPathString.c_str(),
+          R"(","languageId":"capnp","version":1,"text":"@0xdba53d6c0e9fe303;\nstruct Person {\n  name @0 :Text;\n  age @1 :UInt32;\n  email @\n}\n"}}})")))
+      .wait(io.waitScope);
+
+  captured.output.clear();
+  handler
+      .handleMessage(lspMessage(kj::str(
+          R"({"jsonrpc":"2.0","id":2,"method":"textDocument/completion","params":{"textDocument":{"uri":"file://)",
+          schemaPathString.c_str(),
+          R"("},"position":{"line":4,"character":9},"context":{"triggerKind":2,"triggerCharacter":"@"}}})")))
+      .wait(io.waitScope);
+
+  {
+    capnp::MallocMessageBuilder response;
+    decodeJson(
+        responseJson(
+            kj::StringPtr(captured.output.data(), captured.output.size())),
+        response);
+    auto root = response.getRoot<capnp::JsonValue>().asReader();
+    auto result = getObjectField(root, "result");
+    require(
+        result.isArray() && result.getArray().size() == 1,
+        "completion should return exactly one item");
+    auto item = result.getArray()[0];
+    require(
+        getObjectField(item, "label").getString() == "2",
+        "completion should suggest the next ordinal from the open buffer");
+    require(
+        getObjectField(item, "kind").getNumber() == 12,
+        "completion item should use the Value kind");
+    auto textEdit = getObjectField(item, "textEdit");
+    require(
+        getObjectField(textEdit, "newText").getString() == "2",
+        "completion text edit should insert the next ordinal");
+    auto range = getObjectField(textEdit, "range");
+    auto start = getObjectField(range, "start");
+    auto end = getObjectField(range, "end");
+    require(
+        getObjectField(start, "line").getNumber() == 4 &&
+            getObjectField(start, "character").getNumber() == 9 &&
+            getObjectField(end, "line").getNumber() == 4 &&
+            getObjectField(end, "character").getNumber() == 9,
+        "completion text edit range should be empty at the cursor");
+  }
+
+  captured.output.clear();
+  handler
+      .handleMessage(lspMessage(kj::str(
+          R"({"jsonrpc":"2.0","method":"textDocument/didChange","params":{"textDocument":{"uri":"file://)",
+          schemaPathString.c_str(),
+          R"(","version":2},"contentChanges":[{"text":"@0xdba53d6c0e9fe303;\nstruct Person {\n  name @0 :Text;\n  age @1 :UInt32;\n  phone @2 :Text;\n  email @\n}\n"}]}})")))
+      .wait(io.waitScope);
+
+  captured.output.clear();
+  handler
+      .handleMessage(lspMessage(kj::str(
+          R"({"jsonrpc":"2.0","id":3,"method":"textDocument/completion","params":{"textDocument":{"uri":"file://)",
+          schemaPathString.c_str(),
+          R"("},"position":{"line":5,"character":9}}})")))
+      .wait(io.waitScope);
+
+  {
+    capnp::MallocMessageBuilder response;
+    decodeJson(
+        responseJson(
+            kj::StringPtr(captured.output.data(), captured.output.size())),
+        response);
+    auto root = response.getRoot<capnp::JsonValue>().asReader();
+    auto result = getObjectField(root, "result");
+    require(
+        result.isArray() && result.getArray().size() == 1 &&
+            getObjectField(result.getArray()[0], "label").getString() == "3",
+        "completion should reflect didChange edits, not the file on disk");
+  }
+
+  captured.output.clear();
+  handler
+      .handleMessage(lspMessage(kj::str(
+          R"({"jsonrpc":"2.0","method":"textDocument/didChange","params":{"textDocument":{"uri":"file://)",
+          schemaPathString.c_str(),
+          R"(","version":3},"contentChanges":[{"text":"@0xdba53d6c0e9fe303;\nstruct Person {\n  name @0 :Text;\n  un\n}\n"}]}})")))
+      .wait(io.waitScope);
+
+  captured.output.clear();
+  handler
+      .handleMessage(lspMessage(kj::str(
+          R"({"jsonrpc":"2.0","id":4,"method":"textDocument/completion","params":{"textDocument":{"uri":"file://)",
+          schemaPathString.c_str(),
+          R"("},"position":{"line":3,"character":4}}})")))
+      .wait(io.waitScope);
+
+  {
+    capnp::MallocMessageBuilder response;
+    decodeJson(
+        responseJson(
+            kj::StringPtr(captured.output.data(), captured.output.size())),
+        response);
+    auto root = response.getRoot<capnp::JsonValue>().asReader();
+    auto result = getObjectField(root, "result");
+    require(
+        result.isArray() && result.getArray().size() == 7,
+        "keyword completion in a struct body should offer seven keywords");
+    bool foundUnion = false;
+    for (auto item : result.getArray()) {
+      if (getObjectField(item, "label").getString() != "union") {
+        continue;
+      }
+      foundUnion = true;
+      require(
+          getObjectField(item, "kind").getNumber() == 14,
+          "keyword completion items should use the Keyword kind");
+      auto textEdit = getObjectField(item, "textEdit");
+      require(
+          getObjectField(textEdit, "newText").getString() == "union",
+          "keyword text edit should insert the keyword");
+      auto range = getObjectField(textEdit, "range");
+      auto start = getObjectField(range, "start");
+      auto end = getObjectField(range, "end");
+      require(
+          getObjectField(start, "line").getNumber() == 3 &&
+              getObjectField(start, "character").getNumber() == 2 &&
+              getObjectField(end, "line").getNumber() == 3 &&
+              getObjectField(end, "character").getNumber() == 4,
+          "keyword text edit range should cover the typed prefix");
+    }
+    require(foundUnion, "struct body keyword completion should include union");
+  }
+
+  captured.output.clear();
+  handler
+      .handleMessage(lspMessage(kj::str(
+          R"({"jsonrpc":"2.0","method":"textDocument/didClose","params":{"textDocument":{"uri":"file://)",
+          schemaPathString.c_str(),
+          R"("}}})")))
+      .wait(io.waitScope);
+
+  handler
+      .handleMessage(lspMessage(kj::str(
+          R"({"jsonrpc":"2.0","id":5,"method":"textDocument/completion","params":{"textDocument":{"uri":"file://)",
+          schemaPathString.c_str(),
+          R"("},"position":{"line":4,"character":9}}})")))
+      .wait(io.waitScope);
+
+  {
+    capnp::MallocMessageBuilder response;
+    decodeJson(
+        responseJson(
+            kj::StringPtr(captured.output.data(), captured.output.size())),
+        response);
+    auto root = response.getRoot<capnp::JsonValue>().asReader();
+    auto result = getObjectField(root, "result");
+    require(
+        result.isArray() && result.getArray().size() == 0,
+        "completion after didClose should return no items");
+  }
+
+  return 0;
+}

--- a/tests/initialize_config_test.cpp
+++ b/tests/initialize_config_test.cpp
@@ -197,8 +197,8 @@ int main() {
     auto result = getObjectField(responseRoot, "result");
     auto capabilities = getObjectField(result, "capabilities");
     require(
-        !hasObjectField(capabilities, "completionProvider"),
-        "initialize should not advertise completion without a completion handler");
+        hasObjectField(capabilities, "completionProvider"),
+        "initialize should advertise completion support");
     require(
         hasObjectField(capabilities, "hoverProvider"),
         "initialize should advertise hover support");
@@ -434,9 +434,8 @@ struct Person {
     capnp_ls::StdoutWriter writer(kj::mv(stream));
     capnp_ls::LspMessageHandler handler(context, writer);
     handler
-        .handleMessage(kj::str(
-            "Content-Length: 67\r\n\r\n",
-            R"({"jsonrpc":"2.0","id":42,"method":"textDocument/completion"})"))
+        .handleMessage(lspMessage(
+            R"({"jsonrpc":"2.0","id":42,"method":"textDocument/rename"})"))
         .wait(io.waitScope);
 
     capnp::MallocMessageBuilder response;

--- a/tests/keyword_completion_test.cpp
+++ b/tests/keyword_completion_test.cpp
@@ -1,0 +1,253 @@
+// Copyright (c) 2024 Atsushi Tomida
+//
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
+
+#include "keyword_completion.h"
+#include "kj_compat.h"
+#include <kj/debug.h>
+#include <string>
+
+namespace {
+
+void require(bool condition, kj::StringPtr message) {
+  if (!condition) {
+    KJ_FAIL_REQUIRE(message);
+  }
+}
+
+// Internal 1-based position right after the first occurrence of needle.
+// ASCII-only inputs: byte columns equal UTF-16 columns.
+capnp_ls::Position cursorAfter(kj::StringPtr text, kj::StringPtr needle) {
+  std::string haystack(text.cStr(), text.size());
+  auto found = haystack.find(std::string(needle.cStr(), needle.size()));
+  require(found != std::string::npos, "test needle should exist in text");
+  size_t offset = found + needle.size();
+  capnp_ls::Position position{1, 1};
+  for (size_t i = 0; i < offset; ++i) {
+    if (haystack[i] == '\n') {
+      ++position.line;
+      position.character = 1;
+    } else {
+      ++position.character;
+    }
+  }
+  return position;
+}
+
+kj::Maybe<capnp_ls::KeywordCompletion>
+compute(kj::StringPtr text, kj::StringPtr needle) {
+  auto position = cursorAfter(text, needle);
+  return capnp_ls::computeKeywordCompletion(
+      text, position.line, position.character);
+}
+
+bool hasKeyword(
+    kj::ArrayPtr<const kj::StringPtr> keywords,
+    kj::StringPtr expected) {
+  for (auto &keyword : keywords) {
+    if (keyword == expected) {
+      return true;
+    }
+  }
+  return false;
+}
+
+void expectKeywords(
+    kj::StringPtr text,
+    kj::StringPtr needle,
+    size_t expectedCount,
+    kj::StringPtr mustContain,
+    kj::StringPtr message) {
+  auto result = compute(text, needle);
+  CAPNP_LS_IF_SOME (completion, result) {
+    require(completion->keywords.size() == expectedCount, message);
+    require(hasKeyword(completion->keywords, mustContain), message);
+    return;
+  }
+  KJ_FAIL_REQUIRE(message, "expected keywords, got none");
+}
+
+void expectNone(kj::StringPtr text, kj::StringPtr needle, kj::StringPtr message) {
+  auto result = compute(text, needle);
+  CAPNP_LS_IF_SOME (completion, result) {
+    (void)completion;
+    KJ_FAIL_REQUIRE(message, "expected none, got keywords");
+  }
+}
+
+} // namespace
+
+int main() {
+  // File scope offers declaration keywords but not union.
+  {
+    kj::StringPtr text = R"(@0xdba53d6c0e9fe303;
+
+stru
+)";
+    expectKeywords(
+        text, "stru", 6, "struct", "file scope should offer declaration keywords");
+    auto result = compute(text, "stru");
+    CAPNP_LS_IF_SOME (completion, result) {
+      require(
+          !hasKeyword(completion->keywords, "union"),
+          "file scope should not offer union");
+      require(
+          hasKeyword(completion->keywords, "using") &&
+              hasKeyword(completion->keywords, "annotation"),
+          "file scope should offer using and annotation");
+      auto position = cursorAfter(text, "stru");
+      require(
+          completion->replaceRange.start.line == position.line &&
+              completion->replaceRange.start.character ==
+                  position.character - 4 &&
+              completion->replaceRange.end == position,
+          "replace range should cover the typed prefix");
+    } else {
+      KJ_FAIL_REQUIRE("file scope should offer keywords");
+    }
+  }
+
+  // Struct bodies additionally offer union.
+  expectKeywords(
+      R"(struct Person {
+  name @0 :Text;
+  un
+}
+)",
+      "un",
+      7,
+      "union",
+      "struct body should offer declaration keywords plus union");
+
+  // Interface bodies offer declaration keywords but not union.
+  {
+    kj::StringPtr text = R"(interface Calc {
+  add @0 () -> ();
+  st
+}
+)";
+    expectKeywords(
+        text, "st", 6, "struct", "interface body should offer declaration keywords");
+    auto result = compute(text, "st");
+    CAPNP_LS_IF_SOME (completion, result) {
+      require(
+          !hasKeyword(completion->keywords, "union"),
+          "interface body should not offer union");
+    }
+  }
+
+  // Enum bodies hold only enumerants.
+  expectNone(
+      R"(enum Color {
+  red @0;
+  gr
+}
+)",
+      "gr",
+      "enum body should not offer keywords");
+
+  // Unnamed union bodies offer only a nested union.
+  expectKeywords(
+      R"(struct S {
+  union {
+    un
+  }
+}
+)",
+      "    un",
+      1,
+      "union",
+      "union body should offer only union");
+
+  // Group bodies offer only a nested union.
+  expectKeywords(
+      R"(struct S {
+  g :group {
+    un
+  }
+}
+)",
+      "un",
+      1,
+      "union",
+      "group body should offer only union");
+
+  // A second statement on the same line still starts a statement.
+  expectKeywords(
+      R"(struct S {
+  a @0 :Bool; un
+}
+)",
+      "un",
+      7,
+      "union",
+      "statement after a ';' on the same line should offer keywords");
+
+  // Manual invocation with no prefix at a statement start.
+  {
+    kj::StringPtr text = "struct S {\n  \n}\n";
+    auto result = capnp_ls::computeKeywordCompletion(text, 2, 3);
+    CAPNP_LS_IF_SOME (completion, result) {
+      require(
+          completion->keywords.size() == 7,
+          "empty prefix at a statement start should offer all keywords");
+      require(
+          completion->replaceRange.start == completion->replaceRange.end,
+          "empty prefix should produce an empty replace range");
+    } else {
+      KJ_FAIL_REQUIRE("empty prefix at a statement start should complete");
+    }
+  }
+
+  // Manual invocation in an empty file.
+  {
+    auto result = capnp_ls::computeKeywordCompletion("", 1, 1);
+    CAPNP_LS_IF_SOME (completion, result) {
+      require(
+          completion->keywords.size() == 6,
+          "empty file should offer file-scope keywords");
+    } else {
+      KJ_FAIL_REQUIRE("empty file should offer keywords");
+    }
+  }
+
+  // Not the first word of the statement.
+  expectNone(
+      "const ma\n",
+      "ma",
+      "second word of a statement should not offer keywords");
+
+  // Type position after ':' is not a keyword position.
+  expectNone(
+      R"(struct S {
+  name :Te
+}
+)",
+      "Te",
+      "type position should not offer keywords");
+
+  // Comments and strings never complete.
+  expectNone(
+      R"(struct S {
+  # stru
+}
+)",
+      "# stru",
+      "comments should not offer keywords");
+  expectNone(
+      R"(const s :Text = "stru)",
+      "\"stru",
+      "strings should not offer keywords");
+
+  // Right after '@' is an ordinal position, not a keyword position.
+  expectNone(
+      R"(struct S {
+  email @
+}
+)",
+      "email @",
+      "'@' positions should not offer keywords");
+
+  return 0;
+}

--- a/tests/ordinal_completion_test.cpp
+++ b/tests/ordinal_completion_test.cpp
@@ -1,0 +1,309 @@
+// Copyright (c) 2024 Atsushi Tomida
+//
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
+
+#include "kj_compat.h"
+#include "ordinal_completion.h"
+#include <kj/debug.h>
+#include <string>
+
+namespace {
+
+void require(bool condition, kj::StringPtr message) {
+  if (!condition) {
+    KJ_FAIL_REQUIRE(message);
+  }
+}
+
+// Internal 1-based position right after the first occurrence of needle.
+// ASCII-only inputs: byte columns equal UTF-16 columns.
+capnp_ls::Position cursorAfter(kj::StringPtr text, kj::StringPtr needle) {
+  std::string haystack(text.cStr(), text.size());
+  auto found = haystack.find(std::string(needle.cStr(), needle.size()));
+  require(found != std::string::npos, "test needle should exist in text");
+  size_t offset = found + needle.size();
+  capnp_ls::Position position{1, 1};
+  for (size_t i = 0; i < offset; ++i) {
+    if (haystack[i] == '\n') {
+      ++position.line;
+      position.character = 1;
+    } else {
+      ++position.character;
+    }
+  }
+  return position;
+}
+
+void expectNext(
+    kj::StringPtr text,
+    kj::StringPtr needle,
+    uint32_t expected,
+    kj::StringPtr message) {
+  auto position = cursorAfter(text, needle);
+  auto result = capnp_ls::computeOrdinalCompletion(
+      text, position.line, position.character);
+  CAPNP_LS_IF_SOME (completion, result) {
+    require(completion->nextOrdinal == expected, message);
+    return;
+  }
+  KJ_FAIL_REQUIRE(message, "expected a completion, got none");
+}
+
+void expectNone(kj::StringPtr text, kj::StringPtr needle, kj::StringPtr message) {
+  auto position = cursorAfter(text, needle);
+  auto result = capnp_ls::computeOrdinalCompletion(
+      text, position.line, position.character);
+  CAPNP_LS_IF_SOME (completion, result) {
+    (void)completion;
+    KJ_FAIL_REQUIRE(message, "expected none, got a completion");
+  }
+}
+
+} // namespace
+
+int main() {
+  // Next ordinal after existing struct fields.
+  expectNext(
+      R"(@0xdba53d6c0e9fe303;
+struct Person {
+  name @0 :Text;
+  age @1 :UInt32;
+  email @
+}
+)",
+      "email @",
+      2,
+      "struct with @0 and @1 should suggest 2");
+
+  // First field of an empty struct.
+  expectNext(
+      R"(struct Empty {
+  first @
+}
+)",
+      "first @",
+      0,
+      "empty struct should suggest 0");
+
+  // Nested struct owns its own ordinal space; outer is unaffected by it.
+  {
+    kj::StringPtr text = R"(struct Outer {
+  a @0 :Bool;
+  b @1 :Bool;
+  c @2 :Bool;
+  struct Inner {
+    x @0 :Bool;
+    y @
+  }
+  d @
+}
+)";
+    expectNext(text, "y @", 1, "nested struct should number independently");
+    expectNext(
+        text, "d @", 3, "outer struct should not count nested struct ordinals");
+  }
+
+  // Union members share the enclosing struct's ordinal space.
+  expectNext(
+      R"(struct Shape {
+  area @0 :Float64;
+  union {
+    circle @1 :Float64;
+    square @
+  }
+}
+)",
+      "square @",
+      2,
+      "union members should share the struct ordinal space");
+
+  // Group members share the enclosing struct's ordinal space.
+  expectNext(
+      R"(struct Point {
+  x @0 :Int32;
+  pos :group {
+    y @1 :Int32;
+    z @
+  }
+}
+)",
+      "z @",
+      2,
+      "group members should share the struct ordinal space");
+
+  // Field after a union counts the union's ordinals.
+  expectNext(
+      R"(struct Shape {
+  area @0 :Float64;
+  union {
+    circle @1 :Float64;
+    square @2 :Float64;
+  }
+  label @
+}
+)",
+      "label @",
+      3,
+      "field after a union should count union ordinals");
+
+  // Enum enumerants get their own space.
+  expectNext(
+      R"(enum Color {
+  red @0;
+  green @1;
+  blue @
+}
+)",
+      "blue @",
+      2,
+      "enum should suggest the next enumerant ordinal");
+
+  // Interface methods get their own space.
+  expectNext(
+      R"(interface Calculator {
+  add @0 (a :Int32, b :Int32) -> (result :Int32);
+  subtract @
+}
+)",
+      "subtract @",
+      1,
+      "interface should suggest the next method ordinal");
+
+  // 64-bit hex IDs are not ordinals.
+  expectNext(
+      R"(@0xdba53d6c0e9fe303;
+
+struct Foo @0xbf5147cbbecf40c1 {
+  a @
+}
+)",
+      "a @",
+      0,
+      "hex type and file IDs should not count as ordinals");
+
+  // Ordinals mentioned in comments do not count.
+  expectNext(
+      R"(struct S {
+  # legacy field was @5
+  a @
+}
+)",
+      "a @",
+      0,
+      "ordinals in comments should not count");
+
+  // Ordinals and braces inside string literals do not count.
+  expectNext(
+      R"(struct S {
+  s @0 :Text = "br { ace @7";
+  t @
+}
+)",
+      "t @",
+      1,
+      "ordinals and braces in strings should not count");
+
+  // Digits already typed are excluded from the scan and covered by the
+  // replacement range.
+  {
+    kj::StringPtr text = R"(struct S {
+  a @0 :Bool;
+  b @1
+}
+)";
+    auto position = cursorAfter(text, "b @1");
+    auto result = capnp_ls::computeOrdinalCompletion(
+        text, position.line, position.character);
+    CAPNP_LS_IF_SOME (completion, result) {
+      require(
+          completion->nextOrdinal == 1,
+          "ordinal being typed should not count toward the maximum");
+      require(
+          completion->replaceRange.start.line == position.line &&
+              completion->replaceRange.end.line == position.line,
+          "replace range should stay on the cursor line");
+      require(
+          completion->replaceRange.start.character == position.character - 1 &&
+              completion->replaceRange.end.character == position.character,
+          "replace range should cover the typed digits");
+    } else {
+      KJ_FAIL_REQUIRE("typed digits should still produce a completion");
+    }
+  }
+
+  // The replacement range is empty when nothing is typed after '@'.
+  {
+    kj::StringPtr text = R"(struct S {
+  a @
+}
+)";
+    auto position = cursorAfter(text, "a @");
+    auto result = capnp_ls::computeOrdinalCompletion(
+        text, position.line, position.character);
+    CAPNP_LS_IF_SOME (completion, result) {
+      require(
+          completion->replaceRange.start == completion->replaceRange.end &&
+              completion->replaceRange.start.character == position.character,
+          "replace range should be empty at the cursor");
+    } else {
+      KJ_FAIL_REQUIRE("bare '@' should produce a completion");
+    }
+  }
+
+  // Ordinals declared after the cursor still count.
+  expectNext(
+      R"(struct S {
+  a @1 :Bool;
+  b @
+  z @0 :Bool;
+}
+)",
+      "b @",
+      2,
+      "ordinals after the cursor should count");
+
+  // Unclosed struct (mid-edit) still completes.
+  expectNext(
+      "struct S {\n  a @0 :Bool;\n  b @",
+      "b @",
+      1,
+      "unclosed struct should still complete");
+
+  // UTF-16 column accounting: the emoji counts as two units.
+  {
+    kj::StringPtr text =
+        "struct S {\n  s @0 :Text = \"\xF0\x9F\x98\x80\"; t @\n}\n";
+    auto result = capnp_ls::computeOrdinalCompletion(text, 2, 25);
+    CAPNP_LS_IF_SOME (completion, result) {
+      require(
+          completion->nextOrdinal == 1,
+          "UTF-16 cursor after an emoji should suggest the next ordinal");
+    } else {
+      KJ_FAIL_REQUIRE("UTF-16 cursor after an emoji should complete");
+    }
+  }
+
+  // No completion without an '@' before the cursor.
+  expectNone(
+      R"(struct S {
+  name
+}
+)",
+      "name",
+      "cursor without a preceding '@' should not complete");
+
+  // No completion at the top level (file IDs are hex, not ordinals).
+  expectNone("@", "@", "top-level '@' should not complete");
+
+  // No completion inside a comment.
+  expectNone(
+      R"(struct S {
+  a @0 :Bool; # note @
+}
+)",
+      "note @",
+      "'@' inside a comment should not complete");
+
+  return 0;
+}


### PR DESCRIPTION
## Summary

- Add completion handling for Cap'n Proto schemas.
- Suggest the next ordinal after typing `@` in struct, interface, enum, union, and group contexts using the unsaved editor buffer.
- Suggest declaration keywords at valid statement starts.
- Advertise `completionProvider` with `@` as a trigger character.

## Impact

Users can request completions while editing schemas before saving. Ordinal completions follow Cap'n Proto numbering scopes, and keyword completions are filtered by the enclosing schema block.

## Validation

- `just test`
- `cmake --build build-v1`
- `ctest --test-dir build-v1 --output-on-failure`